### PR TITLE
Replace isinf with std::isinf.

### DIFF
--- a/jubatus/core/anomaly/lof.cpp
+++ b/jubatus/core/anomaly/lof.cpp
@@ -56,7 +56,7 @@ float calculate_lof(
     sum_neighbor_lrd += it->second;
   }
 
-  if (isinf(sum_neighbor_lrd) && isinf(lrd)) {
+  if (std::isinf(sum_neighbor_lrd) && std::isinf(lrd)) {
     return 1;
   }
 


### PR DESCRIPTION
Using isinf (not std::isinf) causes compilation error on OS X 10.8.
