### PR TITLE
Replace isinf with std::isinf.

### DIFF
--- a/jubatus/core/anomaly/light_lof.cpp
+++ b/jubatus/core/anomaly/light_lof.cpp
@@ -27,7 +27,6 @@
 #include "jubatus/util/lang/shared_ptr.h"
 #include "../common/exception.hpp"
 
-using std::isinf;
 using jubatus::util::data::unordered_map;
 using jubatus::util::data::unordered_set;
 using jubatus::util::lang::shared_ptr;
@@ -62,7 +61,7 @@ float calculate_lof(float lrd, const std::vector<float>& neighbor_lrds) {
   const float sum_neighbor_lrd = std::accumulate(
       neighbor_lrds.begin(), neighbor_lrds.end(), 0.0f);
 
-  if (isinf(sum_neighbor_lrd) && isinf(lrd)) {
+  if (std::isinf(sum_neighbor_lrd) && std::isinf(lrd)) {
     return 1;
   }
 


### PR DESCRIPTION
Using std::isinf causes compilation error in C++11 mode. This relates to https://github.com/jubatus/jubatus_core/pull/20.
