### PR TITLE
Fix test for AddressSanitizer.

### DIFF
--- a/jubatus/core/table/column/column_table_test.cpp
+++ b/jubatus/core/table/column/column_table_test.cpp
@@ -158,8 +158,7 @@ TEST(add, bit_vector) {
   schema.push_back(column_type(column_type::bit_vector_type, 80));
   base.init(schema);
 
-  char buff[10];
-  memset(buff, 0, 10);
+  uint64_t buff[2] = {};
   bit_vector vec(buff, 80);
   vec.reverse_bit(8);
   vec.reverse_bit(3);


### PR DESCRIPTION
bit_vector requires uint64_t memory.
The old code does not have correct size and correct alignment.
Converting char\* to uint64_t breaks strict aliasing rule.
