### PR TITLE
Fix equations in classifier/NHERD update

### DIFF
--- a/jubatus/core/classifier/normal_herd.cpp
+++ b/jubatus/core/classifier/normal_herd.cpp
@@ -85,7 +85,7 @@ void normal_herd::update(
         pos_label,
         storage::val2_t(
             pos_val.v1
-            + std::max(0.f, 1.f - margin) * val_covariance_pos
+                + (1.f - margin) * val_covariance_pos
                     / (variance + 1.f / C),
             1.f
                 / ((1.f / pos_val.v2) + (2 * C + C * C * variance)
@@ -96,7 +96,7 @@ void normal_herd::update(
           neg_label,
           storage::val2_t(
               neg_val.v1
-              - std::max(0.f, 1.f - margin) * val_covariance_neg
+                  - (1.f - margin) * val_covariance_neg
                       / (variance + 1.f / C),
               1.f
                   / ((1.f / neg_val.v2) + (2 * C + C * C * variance)


### PR DESCRIPTION
This PR fixes [#816](https://github.com/jubatus/jubatus/issues/816).
NHERD update equations were wrong. It must have `variance` in the dominators instead of `val_covariance_xxx` in [L89](https://github.com/jubatus/jubatus_core/blob/master/jubatus/core/classifier/normal_herd.cpp#L89) and [L100](https://github.com/jubatus/jubatus_core/blob/master/jubatus/core/classifier/normal_herd.cpp#L100).

It also appends hinge loss function `std::max(0.f, 1.f - margin)` as in the original paper for safety.
Note: this modification has been eliminated thanks to @unnonouno's comment.

For large `regularization-weight` such as 100, NHERD is now stable and no `Inf` appeared.
