### PR TITLE
(WIP) column index should be `size_t` instead of uint64_t

### DIFF
--- a/jubatus/core/common/key_manager.hpp
+++ b/jubatus/core/common/key_manager.hpp
@@ -80,7 +80,7 @@ class key_manager {
 
   jubatus::util::data::unordered_map<std::string, uint64_t> key2id_;
   jubatus::util::data::unordered_map<uint64_t, std::string> id2key_;
-  uint64_t next_id_;
+  size_t next_id_;
 };
 
 inline void swap(key_manager& l, key_manager& r) {  // NOLINT


### PR DESCRIPTION
This PR is to fix [jubatus:issue#596](https://github.com/jubatus/jubatus/issues/596)

this PR is WIP.
