### PR TITLE
Support capture group in onig_filter

### DIFF
--- a/jubatus/core/fv_converter/onig_filter.hpp
+++ b/jubatus/core/fv_converter/onig_filter.hpp
@@ -35,6 +35,11 @@ class regexp_filter : public string_filter {
  private:
   regexp_filter();
 
+  void replace(
+      const std::string& input,
+      const OnigRegion* region,
+      std::ostream& out) const;
+
   regex_t* reg_;
   std::string replace_;
 };

--- a/jubatus/core/fv_converter/regexp_filter_test.cpp
+++ b/jubatus/core/fv_converter/regexp_filter_test.cpp
@@ -110,6 +110,35 @@ TEST(regexp_filter, long_substitute) {
   }
 }
 
+TEST(regexp_filter, group) {
+  regexp_filter f("(apple|banana|orange)", "\\1 juice \\1");
+
+  std::string out;
+  f.filter("apple", out);
+  EXPECT_EQ("apple juice apple", out);
+}
+
+TEST(regexp_filter, group_10) {
+  regexp_filter f("(.)(.)(.)(.)(.)(.)(.)(.)(.)(.)", "\\10");
+
+  std::string out;
+  f.filter("abcdefghij", out);
+  EXPECT_EQ("a0", out);
+}
+
+TEST(regexp_filter, invalid_group_number) {
+  EXPECT_THROW(regexp_filter f("(a)", "\\2"), converter_exception);
+  EXPECT_THROW(regexp_filter f("(a)", "\\2x"), converter_exception);
+}
+
+TEST(regexp_filter, invalid_escape) {
+  EXPECT_THROW(regexp_filter f("(a)", "\\xx"), converter_exception);
+}
+
+TEST(regexp_filter, last_backslash) {
+  EXPECT_THROW(regexp_filter f("(a)", "\\"), converter_exception);
+}
+
 }  // namespace fv_converter
 }  // namespace core
 }  // namespace jubatus


### PR DESCRIPTION
Replace `\\[0-9]` with a captured groups in `onig_filter`.
fix #53 
