### PR TITLE
fix classifier_factory to report error when parameter block is missing 

### DIFF
--- a/jubatus/core/classifier/classifier_factory.cpp
+++ b/jubatus/core/classifier/classifier_factory.cpp
@@ -89,26 +89,51 @@ shared_ptr<classifier_base> classifier_factory::create_classifier(
     }
     res.reset(new passive_aggressive(storage));
   } else if (name == "PA1" || name == "passive_aggressive_1") {
+    if (param.type() == jubatus::util::text::json::json::Null) {
+      throw JUBATUS_EXCEPTION(
+          common::config_exception() << common::exception::error_message(
+              "parameter block is not specified in config"));
+    }
     unlearning_classifier_config conf
         = config_cast_check<unlearning_classifier_config>(param);
     unlearner = create_unlearner(conf);
     res.reset(new passive_aggressive_1(conf, storage));
   } else if (name == "PA2" || name == "passive_aggressive_2") {
+    if (param.type() == jubatus::util::text::json::json::Null) {
+      throw JUBATUS_EXCEPTION(
+          common::config_exception() << common::exception::error_message(
+              "parameter block is not specified in config"));
+    }
     unlearning_classifier_config conf
         = config_cast_check<unlearning_classifier_config>(param);
     unlearner = create_unlearner(conf);
     res.reset(new passive_aggressive_2(conf, storage));
   } else if (name == "CW" || name == "confidence_weighted") {
+    if (param.type() == jubatus::util::text::json::json::Null) {
+      throw JUBATUS_EXCEPTION(
+          common::config_exception() << common::exception::error_message(
+              "parameter block is not specified in config"));
+    }
     unlearning_classifier_config conf
         = config_cast_check<unlearning_classifier_config>(param);
     unlearner = create_unlearner(conf);
     res.reset(new confidence_weighted(conf, storage));
   } else if (name == "AROW" || name == "arow") {
+    if (param.type() == jubatus::util::text::json::json::Null) {
+      throw JUBATUS_EXCEPTION(
+          common::config_exception() << common::exception::error_message(
+              "parameter block is not specified in config"));
+    }
     unlearning_classifier_config conf
         = config_cast_check<unlearning_classifier_config>(param);
     unlearner = create_unlearner(conf);
     res.reset(new arow(conf, storage));
   } else if (name == "NHERD" || name == "normal_herd") {
+    if (param.type() == jubatus::util::text::json::json::Null) {
+      throw JUBATUS_EXCEPTION(
+          common::config_exception() << common::exception::error_message(
+              "parameter block is not specified in config"));
+    }
     unlearning_classifier_config conf
         = config_cast_check<unlearning_classifier_config>(param);
     unlearner = create_unlearner(conf);


### PR DESCRIPTION
Fix #52.

When the following config is given (note that "parameter" block is missing, which is required for PA1):

```
{
  "converter" : {
    "string_filter_types" : {},
    "string_filter_rules" : [],
    "num_filter_types" : {},
    "num_filter_rules" : [],
    "string_types" : {},
    "string_rules" : [
      { "key" : "*", "type" : "str", "sample_weight" : "bin", "global_weight" : "bin" }
    ],
    "num_types" : {},
    "num_rules" : [
      { "key" : "*", "type" : "num" }
    ]
  },
  "method" : "PA1"
}
```

Before applying this patch, the error message is difficult to understand:

```
2014-09-08 16:08:43,965 30606 FATAL [server_util.hpp:147] exception in main thread: Dynamic exception type: jubatus::core::common::jsonconfig::type_error::what: Object is expected, but Null is given. ()
    #0 [jubatus::core::common::exception::error_at_file_*] = ../jubatus/core/common/jsonconfig/config.cpp
    #0 [jubatus::core::common::exception::error_at_line_*] = 80
    #0 [jubatus::core::common::exception::error_at_func_*] = bool jubatus::core::common::jsonconfig::config::contain(const string&) const

```

By applying this patch, the error message become easier to understand:

```
2014-09-08 16:09:04,937 30642 FATAL [server_util.hpp:147] exception in main thread: Dynamic exception type: jubatus::core::common::config_exception::what: jubatus::core::common::config_exception
    #0 [jubatus::core::common::exception::error_message_*] = parameter block is not specified in config
    #0 [jubatus::core::common::exception::error_at_file_*] = ../jubatus/core/classifier/classifier_factory.cpp
    #0 [jubatus::core::common::exception::error_at_line_*] = 95
    #0 [jubatus::core::common::exception::error_at_func_*] = static jubatus::util::lang::shared_ptr<jubatus::core::classifier::classifier_base> jubatus::core::classifier::classifier_factory::create_classifier(const string&, const jubatus::core::common::jsonconfig::config&, jubatus::util::lang::shared_ptr<jubatus::core::storage::storage_base>)
```
