### PR TITLE
fix unlearner does not erase rows correctly

### DIFF
--- a/jubatus/core/recommender/nearest_neighbor_recommender.cpp
+++ b/jubatus/core/recommender/nearest_neighbor_recommender.cpp
@@ -36,7 +36,7 @@ class nearest_neighbor_recommender::unlearning_callback {
   }
 
   void operator()(const std::string& id) {
-    recommender_->clear_row(id);
+    recommender_->unlearn_row(id);
   }
 
  private:
@@ -86,6 +86,14 @@ void nearest_neighbor_recommender::clear_row(const std::string& id) {
   if (unlearner_) {
     unlearner_->remove(id);
   }
+}
+
+/**
+ * Callback from unlearner
+ */
+void nearest_neighbor_recommender::unlearn_row(const std::string& id) {
+  orig_.remove_row(id);
+  get_table()->delete_row(id);
 }
 
 void nearest_neighbor_recommender::update_row(

--- a/jubatus/core/recommender/nearest_neighbor_recommender.hpp
+++ b/jubatus/core/recommender/nearest_neighbor_recommender.hpp
@@ -62,6 +62,7 @@ class nearest_neighbor_recommender : public recommender_base {
   void unpack(msgpack::object o);
 
  private:
+  void unlearn_row(const std::string& id);
   jubatus::util::lang::shared_ptr<table::column_table> get_table();
   jubatus::util::lang::shared_ptr<const table::column_table>
       get_const_table() const;


### PR DESCRIPTION
Currently, NN-based recommender does not erase rows correctly.
Unlearner expects that the callback function (which is registered to the unlearner) does not change the unlearner state.

I changed the callback function from `clear_row` (which calls the `remove` method of unlearner) to `unlearn_row` (which is a new one, does not call `remove` method).
