### PR TITLE
Clustering sometimes gets NaN

### DIFF
--- a/jubatus/core/clustering/clustering_test.cpp
+++ b/jubatus/core/clustering/clustering_test.cpp
@@ -145,6 +145,8 @@ TEST_P(clustering_test, config_validation) {
   ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
 }
 
+
+
 const map<string, string> test_cases[] = {
 #ifdef JUBATUS_USE_EIGEN
   make_case("method", "gmm")

--- a/jubatus/core/clustering/gmm.cpp
+++ b/jubatus/core/clustering/gmm.cpp
@@ -71,7 +71,7 @@ void gmm::batch(const eigen_wsvec_list_t& data, int d, int k) {
         means_[c] += cp * i->data;
         covs_[c] += i->data * (i->data.transpose()) * cp;
         weights[c] += cp;
-        obj -= std::log(cp);
+        obj -= std::log(std::max(cp, 1.0e-45));
       }
     }
     for (int c = 0; c < k; ++c) {

--- a/jubatus/core/clustering/gmm.cpp
+++ b/jubatus/core/clustering/gmm.cpp
@@ -71,7 +71,7 @@ void gmm::batch(const eigen_wsvec_list_t& data, int d, int k) {
         means_[c] += cp * i->data;
         covs_[c] += i->data * (i->data.transpose()) * cp;
         weights[c] += cp;
-        obj -= std::log(std::max(cp, 1.0e-45));
+        obj -= std::log(std::max(cp, std::numeric_limits<double>::min()));
       }
     }
     for (int c = 0; c < k; ++c) {

--- a/jubatus/core/clustering/kmeans_compressor.cpp
+++ b/jubatus/core/clustering/kmeans_compressor.cpp
@@ -214,6 +214,7 @@ void kmeans_compressor::bicriteria_to_coreset(
     squared_min_dist_sum += m.second * m.second * weight;
     weight_sum += weight;
   }
+  squared_min_dist_sum = std::max(squared_min_dist_sum, 1.0e-45);
   std::vector<double> weights;
   double sumw = 0;
   for (size_t i = 0; i < src.size(); ++i) {

--- a/jubatus/core/clustering/kmeans_compressor.cpp
+++ b/jubatus/core/clustering/kmeans_compressor.cpp
@@ -214,7 +214,7 @@ void kmeans_compressor::bicriteria_to_coreset(
     squared_min_dist_sum += m.second * m.second * weight;
     weight_sum += weight;
   }
-  squared_min_dist_sum = std::max(squared_min_dist_sum, 1.0e-45);
+  squared_min_dist_sum = std::max(squared_min_dist_sum, std::numeric_limits<double>::min());
   std::vector<double> weights;
   double sumw = 0;
   for (size_t i = 0; i < src.size(); ++i) {

--- a/jubatus/core/driver/clustering_test.cpp
+++ b/jubatus/core/driver/clustering_test.cpp
@@ -14,6 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
+#include <fenv.h>
+
 #include <vector>
 #include <string>
 #include <set>
@@ -54,29 +56,32 @@ class clustering_test
  protected:
   shared_ptr<driver::clustering> create_driver() const {
     pair<string, string> param = GetParam();
-    clustering_config conf;
-    conf.compressor_method = param.first;
     return shared_ptr<driver::clustering>(
         new driver::clustering(
             shared_ptr<core::clustering::clustering>(
                 new core::clustering::clustering("dummy",
                                                  param.second,
-                                                 conf)),
+                                                 conf_)),
             make_fv_converter()));
   }
   void SetUp() {
+    feenableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW);
     pair<string, string> param = GetParam();
-    clustering_config conf;
-    conf.compressor_method = param.first;
-    conf.bucket_size = 50;
-    conf.bicriteria_base_size = 5;
-    conf.compressed_bucket_size = 10;
+    conf_.k = 2;
+    conf_.compressor_method = param.first;
+    conf_.bucket_size = 200;
+    conf_.compressed_bucket_size = conf_.bucket_size / 10;
+    conf_.bicriteria_base_size = conf_.bucket_size / 100;
+    conf_.bucket_length = 2;
+    conf_.forgetting_factor = 0.0;
+    conf_.forgetting_threshold = 0.5;
     clustering_ = create_driver();
   }
   void TearDown() {
     clustering_.reset();
   }
   shared_ptr<driver::clustering> clustering_;
+  clustering_config conf_;
 };
 
 namespace {  // testing util
@@ -88,22 +93,23 @@ datum single_datum(string key, double v) {
 }
 
 TEST_P(clustering_test, get_revision) {
-  for (int i = 0; i < 2000; ++i) {
+  const int num = conf_.bucket_size * 10;
+  for (int i = 0; i < num; ++i) {
     vector<datum> datums;
     datums.push_back(single_datum("a", 1));
     clustering_->push(datums);
   }
-  ASSERT_EQ(0, clustering_->get_revision());
+  ASSERT_EQ(num / conf_.bucket_size, clustering_->get_revision());
 }
 
 TEST_P(clustering_test, push) {
-  for (int j = 0; j < 21 ; j += 5) {
+  for (int j = 0; j < conf_.bucket_size / 5; ++j) {
     vector<datum> datums;
     for (int i = 0; i < 100; i += 5) {
       datums.push_back(single_datum("a", i * 2));
       datums.push_back(single_datum("b", i * 100));
-      clustering_->push(datums);
     }
+    clustering_->push(datums);
   }
 }
 
@@ -137,7 +143,7 @@ TEST_P(clustering_test, get_k_center) {
   vector<datum> one;
   vector<datum> two;
 
-  for (int j = 0; j < 200 ; ++j) {
+  for (int j = 0; j < conf_.bucket_size / 2; ++j) {
     datum a, b;
     a.num_values_.push_back(make_pair("a", -10 + r.next_gaussian() * 20));
     a.num_values_.push_back(make_pair("b", -200 + r.next_gaussian() * 400));
@@ -152,7 +158,7 @@ TEST_P(clustering_test, get_k_center) {
   clustering_->do_clustering();
   {
     vector<datum> result = clustering_->get_k_center();
-    ASSERT_EQ(2, result.size());
+    ASSERT_EQ(conf_.k, result.size());
     ASSERT_LT(1, result[0].num_values_.size());
     if (result[0].num_values_[0].first == "a"
         || result[0].num_values_[0].first == "b") {
@@ -172,6 +178,33 @@ TEST_P(clustering_test, get_k_center) {
     }
   }
 }
+
+TEST_P(clustering_test, integer_center) {
+  jubatus::util::math::random::mtrand r(0);
+  const int quantity = conf_.bucket_size * 5;
+  std::vector<datum> data(quantity);
+
+  for (int i = 0; i < quantity ; ++i) {
+    data[i].num_values_.push_back(make_pair("x", 100 + r.next_int(-10, 10)));
+  }
+
+  clustering_->push(data);
+  const std::vector<fv_converter::datum> centers = clustering_->get_k_center();
+
+  ASSERT_EQ(conf_.k, centers.size());
+  /*  debug out
+  for (size_t i = 0; i < centers.size(); ++i) {
+    std::cout << i << " :[";
+    for (size_t j = 0; j < centers[i].num_values_.size(); ++j) {
+      std::cout
+        << centers[i].num_values_[j].first << " => "
+        << centers[i].num_values_[j].second << ", ";
+    }
+    std::cout << "]" << std::endl;;
+  }
+  //*/
+}
+
 struct check_points {
   float a;
   float b;
@@ -204,7 +237,7 @@ TEST_P(clustering_test, get_nearest_members) {
 
   set<check_points, check_point_compare> points;
 
-  for (int i = 0; i < 200 ; ++i) {
+  for (int i = 0; i < conf_.bucket_size * 2 + 1; ++i) {
     datum x, y;
     float a = 10 + r.next_gaussian() * 20;
     float b = 1000 + r.next_gaussian() * 400;
@@ -224,7 +257,7 @@ TEST_P(clustering_test, get_nearest_members) {
 
   {
     vector<datum> result = clustering_->get_k_center();
-    ASSERT_EQ(2u, result.size());
+    ASSERT_EQ(conf_.k, result.size());
   }
 
   set<check_points, check_point_compare>::const_iterator it;
@@ -239,7 +272,7 @@ TEST_P(clustering_test, get_nearest_members) {
     for (size_t i = 0; i < result.size(); ++i) {
       const vector<pair<string, double> >& near_points =
           result[i].second.num_values_;
-      ASSERT_EQ(2u, near_points.size());
+      ASSERT_EQ(2, near_points.size());  // must be 2-dimentional
       ASSERT_EQ("a", near_points[0].first);
       ASSERT_EQ("b", near_points[1].first);
       ASSERT_NE(points.end(),
@@ -256,7 +289,7 @@ TEST_P(clustering_test, get_nearest_center) {
   vector<datum> one;
   vector<datum> two;
 
-  for (int i = 0; i < 1000 ; ++i) {
+  for (int i = 0; i < conf_.bucket_size * 2; ++i) {
     datum x, y;
     x.num_values_.push_back(make_pair("a", 10 + r.next_gaussian() * 20));
     x.num_values_.push_back(make_pair("b", 1000 + r.next_gaussian() * 400));
@@ -272,7 +305,7 @@ TEST_P(clustering_test, get_nearest_center) {
 
   {
     vector<datum> result = clustering_->get_k_center();
-    ASSERT_EQ(2, result.size());
+    ASSERT_EQ(conf_.k, result.size());
   }
 
   for (int i = 0; i < 100; ++i) {

--- a/jubatus/core/driver/clustering_test.cpp
+++ b/jubatus/core/driver/clustering_test.cpp
@@ -65,7 +65,6 @@ class clustering_test
             make_fv_converter()));
   }
   void SetUp() {
-    feenableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW);
     pair<string, string> param = GetParam();
     conf_.k = 2;
     conf_.compressor_method = param.first;

--- a/jubatus/core/driver/clustering_test.cpp
+++ b/jubatus/core/driver/clustering_test.cpp
@@ -14,8 +14,6 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-#include <fenv.h>
-
 #include <vector>
 #include <string>
 #include <set>


### PR DESCRIPTION
Originally reported by Hiroshi Kuwajima's [post](https://groups.google.com/d/msg/jubatus/J8dDkXKj7JE/S8hE2HbM0v0J) 

There are devide-by-zero and log(0) calculation exists.
It appears values with limited distribution(like integer).
For first aid, it should use very small value instead of zero.

Some radical(or mathematical) solution will be needed further.