### PR TITLE
fix index of update_at_ function

### DIFF
--- a/jubatus/core/table/column/abstract_column.hpp
+++ b/jubatus/core/table/column/abstract_column.hpp
@@ -332,7 +332,7 @@ class typed_column<bit_vector> : public detail::abstract_column_base {
 
   void update_at_(size_t index, const void* raw_data) {
     if (raw_data) {
-      memcpy(get_data_at_(size() - 1), raw_data, bytes_per_value_());
+      memcpy(get_data_at_(index), raw_data, bytes_per_value_());
     } else {
       memset(get_data_at_(size() - 1), 0, bytes_per_value_());
     }

--- a/jubatus/core/table/column/abstract_column.hpp
+++ b/jubatus/core/table/column/abstract_column.hpp
@@ -334,7 +334,7 @@ class typed_column<bit_vector> : public detail::abstract_column_base {
     if (raw_data) {
       memcpy(get_data_at_(index), raw_data, bytes_per_value_());
     } else {
-      memset(get_data_at_(size() - 1), 0, bytes_per_value_());
+      memset(get_data_at_(index), 0, bytes_per_value_());
     }
   }
 

--- a/jubatus/core/table/column/abstract_column_test.cpp
+++ b/jubatus/core/table/column/abstract_column_test.cpp
@@ -22,6 +22,9 @@
 using jubatus::core::table::detail::abstract_column;
 using jubatus::core::table::column_type;
 using jubatus::core::table::bit_vector;
+using jubatus::core::table::bit_vector_column;
+using jubatus::core::table::column_type;
+
 
 TEST(abstract_column, pack_and_unpack) {
   const size_t n = 10;
@@ -102,4 +105,22 @@ TEST(abstract_column, bit_vector_pack_and_unpack) {
   EXPECT_THROW({
     obj.convert(&dest2);
   }, jubatus::core::table::type_unmatch_exception);
+}
+
+TEST(abstract_column, update_at_correct_index) {
+  const int width = 80;
+  column_type type(column_type::bit_vector_type, width);
+  bit_vector_column bvc(type);
+  bit_vector value1(width);
+
+  value1.set_bit(1);
+  bvc.push_back(value1);
+  bvc.push_back(value1);
+
+  bit_vector value2(width);
+  value2.set_bit(2);
+  bvc.update(0, value2);
+
+  bit_vector may_be_value2(bvc[0]);
+  ASSERT_EQ(value2, may_be_value2);
 }


### PR DESCRIPTION
Nearest Neighbor set a row for an incorrect id when it tries to overwrite the row of existing ids.
This patch fixes the bug. 