### PR TITLE
anomaly unlearner should delete ID in order of registration

### DIFF
--- a/jubatus/core/anomaly/light_lof.cpp
+++ b/jubatus/core/anomaly/light_lof.cpp
@@ -174,12 +174,6 @@ void light_lof::set_row(const std::string& id, const common::sfv_t& sfv) {
   // Primarily add id to lof table with dummy parameters.
   // update_entries() below overwrites this row.
   table->add(id, table::owner(my_id_), -1.f, -1.f);
-
-  for (unordered_set<std::string>::const_iterator it = update_set.begin();
-       it != update_set.end(); ++it) {
-    touch(*it);
-  }
-
   update_set.insert(id);
   update_entries(update_set);
 }


### PR DESCRIPTION
fix issue #92 

`anomaly::set_row` should not `touch()` neighbors of updated ID. 
It touching neighbors means that `unlearner` delete IDs out of order of registration.
it is counter-intuitive behavior.