### PR TITLE
retain projection was not used

### DIFF
--- a/jubatus/core/recommender/euclid_lsh.cpp
+++ b/jubatus/core/recommender/euclid_lsh.cpp
@@ -234,7 +234,6 @@ vector<float> euclid_lsh::calculate_lsh(const common::sfv_t& query) const {
 }
 
 vector<float> euclid_lsh::get_projection(uint32_t seed) const {
-  vector<float> tmpl_proj;
   if (retain_projection_) {
     scoped_lock lk(cache_lock_);  // lock is needed only retain_projection
     vector<float>& proj = projection_cache_[seed];

--- a/jubatus/core/recommender/euclid_lsh.hpp
+++ b/jubatus/core/recommender/euclid_lsh.hpp
@@ -22,6 +22,8 @@
 #include <string>
 #include <vector>
 #include "jubatus/util/data/unordered_map.h"
+#include "jubatus/util/concurrent/lock.h"
+#include "jubatus/util/concurrent/mutex.h"
 #include "jubatus/util/lang/shared_ptr.h"
 #include "jubatus/util/text/json.h"
 #include "recommender_base.hpp"
@@ -110,7 +112,9 @@ class euclid_lsh : public recommender_base {
   float bin_width_;
   uint32_t num_probe_;
 
-  mutable jubatus::util::data::unordered_map<uint32_t, std::vector<float> > projection_cache_;
+  mutable jubatus::util::data::unordered_map<uint32_t, std::vector<float> >
+      projection_cache_;
+  mutable jubatus::util::concurrent::mutex cache_lock_;
   bool retain_projection_;
 };
 

--- a/jubatus/core/recommender/euclid_lsh.hpp
+++ b/jubatus/core/recommender/euclid_lsh.hpp
@@ -100,8 +100,8 @@ class euclid_lsh : public recommender_base {
   void unpack(msgpack::object o);
 
  private:
-  std::vector<float> calculate_lsh(const common::sfv_t& query);
-  std::vector<float> get_projection(uint32_t seed);
+  std::vector<float> calculate_lsh(const common::sfv_t& query) const;
+  std::vector<float> get_projection(uint32_t seed) const;
 
   void initialize_model();
 
@@ -110,7 +110,7 @@ class euclid_lsh : public recommender_base {
   float bin_width_;
   uint32_t num_probe_;
 
-  jubatus::util::data::unordered_map<uint32_t, std::vector<float> > projection_;
+  mutable jubatus::util::data::unordered_map<uint32_t, std::vector<float> > projection_cache_;
   bool retain_projection_;
 };
 


### PR DESCRIPTION
fix #98 
Caching of random vector generation may be good for improving performance.
But cache control needs exclusive access control.
It depends on how calculation is heavy. 