### PR TITLE
Add classifiers headers to install headers

### DIFF
--- a/jubatus/core/classifier/wscript
+++ b/jubatus/core/classifier/wscript
@@ -19,6 +19,16 @@ def build(bld):
       'classifier_factory.hpp',
       'classifier_type.hpp',
       'classifier_config.hpp',
+      'classifier.hpp',
+      'linear_classifier.hpp',
+      'arow.hpp',
+      'confidence_weighted.hpp',
+      'normal_herd.hpp',
+      'passive_aggressive.hpp',
+      'passive_aggressive_1.hpp',
+      'passive_aggressive_2.hpp',
+      'perceptron.hpp',
+      'nearest_neighbor_classifier.hpp',
       ]
   use = ['jubatus_util']
 

--- a/jubatus/core/storage/wscript
+++ b/jubatus/core/storage/wscript
@@ -38,6 +38,8 @@ def build(bld):
       'bit_vector.hpp',
       'sparse_matrix_storage.hpp',
       'recommender_storage_base.hpp',
+      'local_storage.hpp',
+      'local_storage_mixture.hpp',
       ]
   use = ['jubatus_util', 'MSGPACK']
 


### PR DESCRIPTION
I want to use jubatus_core as a library.
[suma/ruby-jubatus](https://github.com/suma/ruby-jubatus) uses jubatus_core class directly,  it needs each internal class definition of C++ headers.

Is it necessary to public many headers If jubatus_core project hope to be used as a library?
Of course, internal API and header definition can be changed by version up, but I think library versioning can avoid bad API use. I give up API compatibility major version up still in rapid development of jubatus_core.