### PR TITLE
implement inverted_index_euclid recommender method

### DIFF
--- a/jubatus/core/recommender/inverted_index.hpp
+++ b/jubatus/core/recommender/inverted_index.hpp
@@ -64,7 +64,7 @@ class inverted_index : public recommender_base {
   void pack(framework::packer& packer) const;
   void unpack(msgpack::object o);
 
- private:
+ protected:
   jubatus::util::lang::shared_ptr<storage::mixable_inverted_index_storage>
       mixable_storage_;
   jubatus::util::lang::shared_ptr<unlearner::unlearner_base>

--- a/jubatus/core/recommender/inverted_index_euclid.cpp
+++ b/jubatus/core/recommender/inverted_index_euclid.cpp
@@ -1,0 +1,88 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2016 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+#include "inverted_index_euclid.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace jubatus {
+namespace core {
+namespace recommender {
+
+inverted_index_euclid::inverted_index_euclid() {
+}
+
+inverted_index_euclid::~inverted_index_euclid() {
+}
+
+void inverted_index_euclid::similar_row(
+    const common::sfv_t& query,
+    std::vector<std::pair<std::string, float> >& ids,
+    size_t ret_num) const {
+  ids.clear();
+  if (ret_num == 0) {
+    return;
+  }
+  mixable_storage_->get_model()->calc_euclid_scores(query, ids, ret_num);
+}
+
+void inverted_index_euclid::similar_row(
+    const std::string& id,
+    std::vector<std::pair<std::string, float> >& ids,
+    size_t ret_num) const {
+  ids.clear();
+  common::sfv_t sfv;
+  orig_.get_row(id, sfv);
+  similar_row(sfv, ids, ret_num);
+}
+
+/**
+ * Reverse the sign of each score.
+ */
+void inverted_index_euclid::neighbor_row(
+    const common::sfv_t& query,
+    std::vector<std::pair<std::string, float> >& ids,
+    size_t ret_num) const {
+  similar_row(query, ids, ret_num);
+  for (size_t i = 0; i < ids.size(); ++i) {
+    ids[i].second = -ids[i].second;
+  }
+}
+
+/**
+ * Reverse the sign of each score.
+ */
+void inverted_index_euclid::neighbor_row(
+    const std::string& id,
+    std::vector<std::pair<std::string, float> >& ids,
+    size_t ret_num) const {
+  similar_row(id, ids, ret_num);
+  for (size_t i = 0; i < ids.size(); ++i) {
+    ids[i].second = -ids[i].second;
+  }
+}
+
+std::string inverted_index_euclid::type() const {
+  return std::string("inverted_index_euclid");
+}
+
+}  // namespace recommender
+}  // namespace core
+}  // namespace jubatus

--- a/jubatus/core/recommender/inverted_index_euclid.hpp
+++ b/jubatus/core/recommender/inverted_index_euclid.hpp
@@ -1,0 +1,58 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2016 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+#ifndef JUBATUS_CORE_RECOMMENDER_INVERTED_INDEX_EUCLID_HPP_
+#define JUBATUS_CORE_RECOMMENDER_INVERTED_INDEX_EUCLID_HPP_
+
+#include <string>
+#include <utility>
+#include <vector>
+#include "inverted_index.hpp"
+
+namespace jubatus {
+namespace core {
+namespace recommender {
+
+class inverted_index_euclid : public inverted_index {
+ public:
+  inverted_index_euclid();
+  ~inverted_index_euclid();
+
+  void similar_row(
+      const common::sfv_t& query,
+      std::vector<std::pair<std::string, float> >& ids,
+      size_t ret_num) const;
+  void similar_row(
+      const std::string& id,
+      std::vector<std::pair<std::string, float> >& ids,
+      size_t ret_num) const;
+  void neighbor_row(
+      const common::sfv_t& query,
+      std::vector<std::pair<std::string, float> >& ids,
+      size_t ret_num) const;
+  void neighbor_row(
+      const std::string& id,
+      std::vector<std::pair<std::string, float> >& ids,
+      size_t ret_num) const;
+
+  std::string type() const;
+};
+
+}  // namespace recommender
+}  // namespace core
+}  // namespace jubatus
+
+#endif  // JUBATUS_CORE_RECOMMENDER_INVERTED_INDEX_EUCLID_HPP_

--- a/jubatus/core/recommender/recommender.hpp
+++ b/jubatus/core/recommender/recommender.hpp
@@ -18,6 +18,7 @@
 #define JUBATUS_CORE_RECOMMENDER_RECOMMENDER_HPP_
 
 #include "inverted_index.hpp"
+#include "inverted_index_euclid.hpp"
 #include "lsh.hpp"
 #include "euclid_lsh.hpp"
 #include "minhash.hpp"

--- a/jubatus/core/recommender/recommender_factory.cpp
+++ b/jubatus/core/recommender/recommender_factory.cpp
@@ -90,6 +90,9 @@ shared_ptr<recommender_base> recommender_factory::create_recommender(
       }
     }
     return shared_ptr<recommender_base>(new inverted_index);
+  } else if (name == "inverted_index_euclid") {
+    // inverted_index_euclid doesn't have parameter
+    return shared_ptr<recommender_base>(new inverted_index_euclid);
   } else if (name == "minhash") {
     return shared_ptr<recommender_base>(
         new minhash(config_cast_check<minhash::config>(param)));

--- a/jubatus/core/recommender/wscript
+++ b/jubatus/core/recommender/wscript
@@ -10,6 +10,7 @@ def build(bld):
     'recommender_mock_storage.cpp',
     'recommender_mock_util.cpp',
     'inverted_index.cpp',
+    'inverted_index_euclid.cpp',
     'minhash.cpp',
     'lsh.cpp',
     'recommender_factory.cpp',

--- a/jubatus/core/storage/inverted_index_storage.cpp
+++ b/jubatus/core/storage/inverted_index_storage.cpp
@@ -365,6 +365,48 @@ void inverted_index_storage::calc_scores(
   }
 }
 
+/**
+ * Returns the nearest neighbors measured by euclidean distance.
+ * Scores are represented in sign-inverted euclidean distance (<= 0);
+ * i.e., larger score means high similarity.
+ */
+void inverted_index_storage::calc_euclid_scores(
+    const common::sfv_t& query,
+    vector<pair<string, float> >& scores,
+    size_t ret_num) const {
+  std::vector<float> i_scores(column2id_.get_max_id() + 1, 0.0);
+  for (size_t i = 0; i < query.size(); ++i) {
+    const string& fid = query[i].first;
+    float val = query[i].second;
+    add_inp_scores(fid, val, i_scores);
+  }
+
+  storage::fixed_size_heap<pair<float, uint64_t>,
+                           std::greater<pair<float, uint64_t> > > heap(ret_num);
+
+  float query_norm = calc_l2norm(query);
+  for (size_t i = 0; i < i_scores.size(); ++i) {
+    float norm = calc_columnl2norm(i);
+
+    // `d2` is a squared euclidean distance.
+    // In edgy cases, `d2` may sliglty become negative (which is actually
+    // expected to be 0) due to the floating point precision problem.
+    // This cause `sqrt(d2)` to return NaN, which is not what we want.
+    // To avoid this we use `sqrt(max(0, d2))`.
+    float d2 = query_norm * query_norm + norm * norm - 2 * i_scores[i];
+    heap.push(make_pair(-std::sqrt(std::max(0.0f, d2)), i));
+  }
+
+  vector<pair<float, uint64_t> > sorted_scores;
+  heap.get_sorted(sorted_scores);
+
+  for (size_t i = 0; i < sorted_scores.size() && i < ret_num; ++i) {
+    scores.push_back(
+        make_pair(column2id_.get_key(sorted_scores[i].second),
+                  sorted_scores[i].first));
+  }
+}
+
 float inverted_index_storage::calc_l2norm(const common::sfv_t& sfv) {
   float ret = 0.f;
   for (size_t i = 0; i < sfv.size(); ++i) {

--- a/jubatus/core/storage/inverted_index_storage.hpp
+++ b/jubatus/core/storage/inverted_index_storage.hpp
@@ -69,6 +69,11 @@ class inverted_index_storage {
       std::vector<std::pair<std::string, float> >& scores,
       size_t ret_num) const;
 
+  void calc_euclid_scores(
+      const common::sfv_t& sfv,
+      std::vector<std::pair<std::string, float> >& scores,
+      size_t ret_num) const;
+
   void get_diff(diff_type& diff_str) const;
   bool put_diff(const diff_type& mixed_diff);
   void mix(const diff_type& lhs_str, diff_type& rhs_str) const;

--- a/jubatus/core/storage/inverted_index_storage_test.cpp
+++ b/jubatus/core/storage/inverted_index_storage_test.cpp
@@ -84,6 +84,36 @@ TEST(inverted_index_storage, trivial) {
   EXPECT_EQ("r2", scores2[2].first);
 }
 
+TEST(inverted_index_storage, trivial_euclid) {
+  inverted_index_storage s;
+  // r1: (1, 1, 1, 0, 0)
+  s.set("c1", "r1", 1);
+  s.set("c2", "r1", 1);
+  s.set("c3", "r1", 1);
+  // r2: (1, 0, 1, 1, 0)
+  s.set("c1", "r2", 1);
+  s.set("c3", "r2", 1);
+  s.set("c4", "r2", 1);
+  // r3: (0, 1, 0, 0, 1)
+  s.set("c2", "r3", 1);
+  s.set("c5", "r3", 1);
+
+  // v:  (1, 1, 0, 0, 0)
+  common::sfv_t v;
+  v.push_back(make_pair("c1", 1.0));
+  v.push_back(make_pair("c2", 1.0));
+
+  vector<pair<string, float> > scores;
+  s.calc_euclid_scores(v, scores, 100);
+
+  EXPECT_EQ("r1", scores[0].first);
+  EXPECT_FLOAT_EQ(-1, scores[0].second);
+  EXPECT_EQ("r3", scores[1].first);
+  EXPECT_FLOAT_EQ(- sqrt(2), scores[1].second);
+  EXPECT_EQ("r2", scores[2].first);
+  EXPECT_FLOAT_EQ(- sqrt(3), scores[2].second);
+}
+
 TEST(inverted_index_storage, diff) {
   inverted_index_storage s;
   // r1: (1, 1, 0, 0, 0)


### PR DESCRIPTION
I added a new method for recommender that calculates similarities based on exact euclidean distance.
This method is mainly expected to be used in conjunction with anomaly LOF.