### PR TITLE
Add assume_unrewarded option to bandit

### DIFF
--- a/jubatus/core/bandit/bandit_factory_test.cpp
+++ b/jubatus/core/bandit/bandit_factory_test.cpp
@@ -31,6 +31,7 @@ namespace bandit {
 
 TEST(bandit_factory, epsilon_greedy) {
   json::json js(new json::json_object);
+  js["assume_unrewarded"] = json::to_json(true);
   js["epsilon"] = json::to_json(0.5);
   common::jsonconfig::config conf(js);
   shared_ptr<bandit_base> p = bandit_factory::create("epsilon_greedy", conf);
@@ -39,6 +40,7 @@ TEST(bandit_factory, epsilon_greedy) {
 
 TEST(bandit_factory, ucb1) {
   json::json js(new json::json_object);
+  js["assume_unrewarded"] = json::to_json(true);
   common::jsonconfig::config conf(js);
   shared_ptr<bandit_base> p = bandit_factory::create("ucb1", conf);
   EXPECT_EQ("ucb1", p->name());
@@ -46,6 +48,7 @@ TEST(bandit_factory, ucb1) {
 
 TEST(bandit_factory, softmax) {
   json::json js(new json::json_object);
+  js["assume_unrewarded"] = json::to_json(true);
   js["tau"] = json::to_json(0.5);
   common::jsonconfig::config conf(js);
   shared_ptr<bandit_base> p = bandit_factory::create("softmax", conf);
@@ -54,6 +57,7 @@ TEST(bandit_factory, softmax) {
 
 TEST(bandit_factory, exp3) {
   json::json js(new json::json_object);
+  js["assume_unrewarded"] = json::to_json(true);
   js["gamma"] = json::to_json(0.5);
   common::jsonconfig::config conf(js);
   shared_ptr<bandit_base> p = bandit_factory::create("exp3", conf);

--- a/jubatus/core/bandit/epsilon_greedy.cpp
+++ b/jubatus/core/bandit/epsilon_greedy.cpp
@@ -26,8 +26,8 @@ namespace jubatus {
 namespace core {
 namespace bandit {
 
-epsilon_greedy::epsilon_greedy(double eps)
-    : eps_(eps), s_(false) {
+epsilon_greedy::epsilon_greedy(bool assume_unrewarded, double eps)
+    : eps_(eps), s_(assume_unrewarded) {
   if (eps < 0 || 1 < eps) {
     throw JUBATUS_EXCEPTION(
         common::invalid_parameter("0 <= epsilon <= 1"));

--- a/jubatus/core/bandit/epsilon_greedy.cpp
+++ b/jubatus/core/bandit/epsilon_greedy.cpp
@@ -27,7 +27,7 @@ namespace core {
 namespace bandit {
 
 epsilon_greedy::epsilon_greedy(double eps)
-    : eps_(eps) {
+    : eps_(eps), s_(false) {
   if (eps < 0 || 1 < eps) {
     throw JUBATUS_EXCEPTION(
         common::invalid_parameter("0 <= epsilon <= 1"));
@@ -41,12 +41,13 @@ std::string epsilon_greedy::select_arm(const std::string& player_id) {
         common::exception::runtime_error("arm is not registered"));
   }
 
+  std::string result;
   if (rand_.next_double() < eps_) {
     // exploration
-    return arms[rand_.next_int(arms.size())];
+    result = arms[rand_.next_int(arms.size())];
   } else {
     // exploitation
-    std::string result = arms[0];
+    result = arms[0];
     double exp_max = s_.get_expectation(player_id, arms[0]);
     for (size_t i = 1; i < arms.size(); ++i) {
       double exp = s_.get_expectation(player_id, arms[i]);
@@ -55,8 +56,9 @@ std::string epsilon_greedy::select_arm(const std::string& player_id) {
         exp_max = exp;
       }
     }
-    return result;
   }
+  s_.notify_selected(player_id, result);
+  return result;
 }
 
 bool epsilon_greedy::register_arm(const std::string& arm_id) {

--- a/jubatus/core/bandit/epsilon_greedy.hpp
+++ b/jubatus/core/bandit/epsilon_greedy.hpp
@@ -29,7 +29,7 @@ namespace bandit {
 
 class epsilon_greedy : public bandit_base {
  public:
-  explicit epsilon_greedy(double eps);
+  epsilon_greedy(bool assume_unrewarded, double eps);
 
   std::string select_arm(const std::string& player_id);
 

--- a/jubatus/core/bandit/exp3.cpp
+++ b/jubatus/core/bandit/exp3.cpp
@@ -27,8 +27,8 @@ namespace jubatus {
 namespace core {
 namespace bandit {
 
-exp3::exp3(double gamma)
-    : gamma_(gamma), s_(false) {
+exp3::exp3(bool assume_unrewarded, double gamma)
+    : gamma_(gamma), s_(assume_unrewarded) {
   if (gamma < 0 || 1 < gamma) {
     throw JUBATUS_EXCEPTION(
         common::invalid_parameter("0 <= gamma <= 1"));

--- a/jubatus/core/bandit/exp3.cpp
+++ b/jubatus/core/bandit/exp3.cpp
@@ -28,7 +28,7 @@ namespace core {
 namespace bandit {
 
 exp3::exp3(double gamma)
-    : gamma_(gamma) {
+    : gamma_(gamma), s_(false) {
   if (gamma < 0 || 1 < gamma) {
     throw JUBATUS_EXCEPTION(
         common::invalid_parameter("0 <= gamma <= 1"));
@@ -66,7 +66,9 @@ std::string exp3::select_arm(const std::string& player_id) {
 
   std::vector<double> weights;
   calc_weights_(player_id, weights);
-  return arms[select_by_weights(weights, rand_)];
+  std::string result = arms[select_by_weights(weights, rand_)];
+  s_.notify_selected(player_id, result);
+  return result;
 }
 
 bool exp3::register_arm(const std::string& arm_id) {

--- a/jubatus/core/bandit/exp3.hpp
+++ b/jubatus/core/bandit/exp3.hpp
@@ -30,7 +30,7 @@ namespace bandit {
 
 class exp3 : public bandit_base {
  public:
-  explicit exp3(double gamma);
+  exp3(bool assume_unrewarded, double gamma);
 
   std::string select_arm(const std::string& player_id);
 

--- a/jubatus/core/bandit/softmax.cpp
+++ b/jubatus/core/bandit/softmax.cpp
@@ -29,8 +29,8 @@ namespace jubatus {
 namespace core {
 namespace bandit {
 
-softmax::softmax(double tau)
-    : tau_(tau), s_(false) {
+softmax::softmax(bool assume_unrewarded, double tau)
+    : tau_(tau), s_(assume_unrewarded) {
   if (tau <= 0) {
     throw JUBATUS_EXCEPTION(
         common::invalid_parameter("0 < tau"));

--- a/jubatus/core/bandit/softmax.cpp
+++ b/jubatus/core/bandit/softmax.cpp
@@ -30,7 +30,7 @@ namespace core {
 namespace bandit {
 
 softmax::softmax(double tau)
-    : tau_(tau) {
+    : tau_(tau), s_(false) {
   if (tau <= 0) {
     throw JUBATUS_EXCEPTION(
         common::invalid_parameter("0 < tau"));
@@ -51,7 +51,9 @@ std::string softmax::select_arm(const std::string& player_id) {
     double expectation = s_.get_expectation(player_id, arms[i]);
     weights.push_back(std::exp(expectation / tau_));
   }
-  return arms[select_by_weights(weights, rand_)];
+  std::string result = arms[select_by_weights(weights, rand_)];
+  s_.notify_selected(player_id, result);
+  return result;
 }
 
 bool softmax::register_arm(const std::string& arm_id) {

--- a/jubatus/core/bandit/softmax.hpp
+++ b/jubatus/core/bandit/softmax.hpp
@@ -29,7 +29,7 @@ namespace bandit {
 
 class softmax : public bandit_base {
  public:
-  explicit softmax(double tau);
+  softmax(bool assume_unrewarded, double tau);
 
   std::string select_arm(const std::string& player_id);
 

--- a/jubatus/core/bandit/summation_storage.cpp
+++ b/jubatus/core/bandit/summation_storage.cpp
@@ -23,7 +23,8 @@ namespace jubatus {
 namespace core {
 namespace bandit {
 
-summation_storage::summation_storage() {
+summation_storage::summation_storage(bool assume_unrewarded)
+    : assume_unrewarded_(assume_unrewarded) {
 }
 
 bool summation_storage::register_arm(const std::string& arm_id) {
@@ -58,13 +59,26 @@ bool summation_storage::delete_arm(const std::string& arm_id) {
   return true;
 }
 
+void summation_storage::notify_selected(
+    const std::string& player_id,
+    const std::string& arm_id) {
+  if (!assume_unrewarded_) {
+    return;
+  }
+  arm_info_map& as = unmixed_[player_id];
+  arm_info& a = as[arm_id];
+  a.trial_count += 1;
+}
+
 bool summation_storage::register_reward(
     const std::string& player_id,
     const std::string& arm_id,
     double reward) {
   arm_info_map& as = unmixed_[player_id];
   arm_info& a = as[arm_id];
-  a.trial_count += 1;
+  if (!assume_unrewarded_) {
+    a.trial_count += 1;
+  }
   a.weight += reward;
   return true;
 }

--- a/jubatus/core/bandit/summation_storage.hpp
+++ b/jubatus/core/bandit/summation_storage.hpp
@@ -30,11 +30,13 @@ class summation_storage {
  public:
   typedef bandit_base::diff_t table_t;
 
-  summation_storage();
+  explicit summation_storage(bool assume_unrewarded);
 
   bool register_arm(const std::string& arm_id);
   bool delete_arm(const std::string& arm_id);
 
+  void notify_selected(const std::string& player_id,
+                       const std::string& arm_id);
   bool register_reward(const std::string& player_id,
                        const std::string& arm_id,
                        double reward);
@@ -59,6 +61,7 @@ class summation_storage {
   MSGPACK_DEFINE(arm_ids_, mixed_, unmixed_);
 
  private:
+  const bool assume_unrewarded_;
   std::vector<std::string> arm_ids_;
   table_t mixed_, unmixed_;
 };

--- a/jubatus/core/bandit/ucb1.cpp
+++ b/jubatus/core/bandit/ucb1.cpp
@@ -27,8 +27,8 @@ namespace jubatus {
 namespace core {
 namespace bandit {
 
-ucb1::ucb1()
-    : s_(false) {
+ucb1::ucb1(bool assume_unrewarded)
+    : s_(assume_unrewarded) {
 }
 
 std::string ucb1::select_arm(const std::string& player_id) {

--- a/jubatus/core/bandit/ucb1.cpp
+++ b/jubatus/core/bandit/ucb1.cpp
@@ -27,7 +27,8 @@ namespace jubatus {
 namespace core {
 namespace bandit {
 
-ucb1::ucb1() {
+ucb1::ucb1()
+    : s_(false) {
 }
 
 std::string ucb1::select_arm(const std::string& player_id) {
@@ -58,6 +59,7 @@ std::string ucb1::select_arm(const std::string& player_id) {
       result = arms[i];
     }
   }
+  s_.notify_selected(player_id, result);
   return result;
 }
 

--- a/jubatus/core/bandit/ucb1.hpp
+++ b/jubatus/core/bandit/ucb1.hpp
@@ -28,7 +28,7 @@ namespace bandit {
 
 class ucb1 : public bandit_base {
  public:
-  ucb1();
+  explicit ucb1(bool assume_unrewarded);
 
   std::string select_arm(const std::string& player_id);
 

--- a/jubatus/core/driver/bandit_test.cpp
+++ b/jubatus/core/driver/bandit_test.cpp
@@ -54,6 +54,7 @@ double simulate_reward(const std::string& arm_id, mtrand& rand) {
 
 TEST(bandit, epsilon_greedy) {
   json::json js(new json::json_object);
+  js["assume_unrewarded"] = json::to_json(true);
   js["epsilon"] = json::to_json(0.1);
   common::jsonconfig::config conf(js);
 


### PR DESCRIPTION
related issue: https://github.com/jubatus/jubatus_core/issues/125

This pull request adds `assume_unrewarded` parameter to each bandit algorithms.
When `assume_unrewarded` is `true`, reward is assumed to zero on calling `select_arm`,
and you don't have to call `register_reward` when reward was actually zero.