### PR TITLE
Implement ignore_kth_same_point option to light_lof (fix #130)

### DIFF
--- a/jubatus/core/anomaly/anomaly_base.hpp
+++ b/jubatus/core/anomaly/anomaly_base.hpp
@@ -66,9 +66,10 @@ class anomaly_base : public framework::model {
   virtual void update_row(const std::string& id, const sfv_diff_t& diff) = 0;
 
   // Updates the row corresponding to given id.
+  // Returns true when the row was successfully updated.
   //
   // Some implementations including lof do not support this function.
-  virtual void set_row(const std::string& id, const common::sfv_t& sfv) = 0;
+  virtual bool set_row(const std::string& id, const common::sfv_t& sfv) = 0;
 
   virtual void get_all_row_ids(std::vector<std::string>& ids) const = 0;
   virtual std::string type() const = 0;

--- a/jubatus/core/anomaly/anomaly_base_test.cpp
+++ b/jubatus/core/anomaly/anomaly_base_test.cpp
@@ -53,7 +53,8 @@ class anomaly_impl : public anomaly_base {
   void update_row(const std::string& id, const sfv_diff_t& diff) {
   }
 
-  void set_row(const std::string& id, const common::sfv_t& sfv) {
+  bool set_row(const std::string& id, const common::sfv_t& sfv) {
+    return true;
   }
 
   void get_all_row_ids(std::vector<std::string>& ids) const {

--- a/jubatus/core/anomaly/light_lof.cpp
+++ b/jubatus/core/anomaly/light_lof.cpp
@@ -44,6 +44,7 @@ namespace {
 
 const uint32_t DEFAULT_NEIGHBOR_NUM = 10;
 const uint32_t DEFAULT_REVERSE_NN_NUM = 30;
+const bool DEFAULT_IGNORE_KTH_SAME_POINT = false;
 
 const size_t KDIST_COLUMN_INDEX = 0;
 const size_t LRD_COLUMN_INDEX = 1;
@@ -75,7 +76,8 @@ float calculate_lof(float lrd, const std::vector<float>& neighbor_lrds) {
 
 light_lof::config::config()
     : nearest_neighbor_num(DEFAULT_NEIGHBOR_NUM),
-      reverse_nearest_neighbor_num(DEFAULT_REVERSE_NN_NUM) {
+      reverse_nearest_neighbor_num(DEFAULT_REVERSE_NN_NUM),
+      ignore_kth_same_point(DEFAULT_IGNORE_KTH_SAME_POINT) {
 }
 
 light_lof::light_lof(
@@ -158,7 +160,24 @@ void light_lof::update_row(const std::string& id, const sfv_diff_t& diff) {
   throw JUBATUS_EXCEPTION(common::unsupported_method(__func__));
 }
 
-void light_lof::set_row(const std::string& id, const common::sfv_t& sfv) {
+bool light_lof::set_row(const std::string& id, const common::sfv_t& sfv) {
+  // Reject adding points that have the same fv for k times.
+  // This helps avoiding LRD to become inf (so that LOF scores of its
+  // neighbors won't go inf.)
+  if (config_.ignore_kth_same_point) {
+    std::vector<std::pair<std::string, float> > nn_result;
+
+    // Find k-1 NNs for the given sfv.
+    // If the distance to the (k-1) th neighbor is 0, the model already
+    // have (k-1) points that have the same feature vector as given sfv.
+    nearest_neighbor_engine_->neighbor_row(
+        sfv, nn_result, config_.nearest_neighbor_num - 1);
+    if (nn_result.size() == (config_.nearest_neighbor_num - 1) &&
+       (nn_result.back().second == 0)) {
+      return false;
+    }
+  }
+
   unordered_set<std::string> update_set;
 
   shared_ptr<column_table> table = mixable_scores_->get_model();
@@ -175,6 +194,8 @@ void light_lof::set_row(const std::string& id, const common::sfv_t& sfv) {
   table->add(id, storage::owner(my_id_), -1.f, -1.f);
   update_set.insert(id);
   update_entries(update_set);
+
+  return true;
 }
 
 void light_lof::get_all_row_ids(std::vector<std::string>& ids) const {

--- a/jubatus/core/anomaly/light_lof.cpp
+++ b/jubatus/core/anomaly/light_lof.cpp
@@ -164,7 +164,7 @@ bool light_lof::set_row(const std::string& id, const common::sfv_t& sfv) {
   // Reject adding points that have the same fv for k times.
   // This helps avoiding LRD to become inf (so that LOF scores of its
   // neighbors won't go inf.)
-  if (config_.ignore_kth_same_point) {
+  if (*config_.ignore_kth_same_point) {
     std::vector<std::pair<std::string, float> > nn_result;
 
     // Find k-1 NNs for the given sfv.

--- a/jubatus/core/anomaly/light_lof.hpp
+++ b/jubatus/core/anomaly/light_lof.hpp
@@ -22,6 +22,7 @@
 #include <vector>
 #include "jubatus/util/data/serialization.h"
 #include "jubatus/util/data/unordered_set.h"
+#include "jubatus/util/data/optional.h"
 #include "jubatus/util/lang/shared_ptr.h"
 #include "anomaly_base.hpp"
 
@@ -50,12 +51,14 @@ class light_lof : public anomaly_base {
 
     int nearest_neighbor_num;
     int reverse_nearest_neighbor_num;
+    jubatus::util::data::optional<bool> ignore_kth_same_point;
 
     template<typename Ar>
     void serialize(Ar& ar) {
       ar
           & JUBA_MEMBER(nearest_neighbor_num)
-          & JUBA_MEMBER(reverse_nearest_neighbor_num);
+          & JUBA_MEMBER(reverse_nearest_neighbor_num)
+          & JUBA_MEMBER(ignore_kth_same_point);
     }
   };
 
@@ -83,7 +86,7 @@ class light_lof : public anomaly_base {
   void clear_row(const std::string& id);
   // update_row is not supported
   void update_row(const std::string& id, const sfv_diff_t& diff);
-  void set_row(const std::string& id, const common::sfv_t& sfv);
+  bool set_row(const std::string& id, const common::sfv_t& sfv);
 
   void get_all_row_ids(std::vector<std::string>& ids) const;
   std::string type() const;

--- a/jubatus/core/anomaly/light_lof_test.cpp
+++ b/jubatus/core/anomaly/light_lof_test.cpp
@@ -74,12 +74,14 @@ common::sfv_t create_2d_point(float x, float y) {
 template<typename NearestNeighborMethod>
 class light_lof_test : public ::testing::Test {
  public:
-  static const int K = 0;
+  static const int K = 10;
   void SetUp() {
     shared_ptr<storage::column_table> nn_table(new storage::column_table);
+    light_lof::config config;
+    config.nearest_neighbor_num = K;
     nn_engine_.reset(new NearestNeighborMethod(
         typename NearestNeighborMethod::config(), nn_table, ID));
-    light_lof_.reset(new light_lof(light_lof::config(), ID, nn_engine_));
+    light_lof_.reset(new light_lof(config, ID, nn_engine_));
 
     mtr_ = jubatus::util::math::random::mtrand(SEED);
   }
@@ -102,7 +104,7 @@ TYPED_TEST_P(light_lof_test, get_all_row_ids) {
       raw_ids, raw_ids + sizeof(raw_ids) / sizeof(raw_ids[0]));
 
   for (size_t i = 0; i < ids.size(); ++i) {
-    this->light_lof_->set_row(ids[i], common::sfv_t());
+    EXPECT_TRUE(this->light_lof_->set_row(ids[i], common::sfv_t()));
   }
   vector<string> actual_ids;
   this->light_lof_->get_all_row_ids(actual_ids);
@@ -110,7 +112,7 @@ TYPED_TEST_P(light_lof_test, get_all_row_ids) {
 
   // duplicated set
   for (size_t i = 0; i < ids.size(); ++i) {
-    this->light_lof_->set_row(ids[i], common::sfv_t());
+    EXPECT_TRUE(this->light_lof_->set_row(ids[i], common::sfv_t()));
   }
   this->light_lof_->get_all_row_ids(actual_ids);
   EXPECT_EQ(ids, actual_ids);
@@ -130,6 +132,24 @@ TYPED_TEST_P(light_lof_test, calc_anomaly_score_on_gaussian_random_samples) {
   // Outlier point should be treated as anomaly.
   const common::sfv_t outlier_query = create_2d_point(0, 3);
   EXPECT_LT(2.f, this->light_lof_->calc_anomaly_score(outlier_query));
+}
+
+TYPED_TEST_P(light_lof_test, ignore_kth_same_point) {
+  common::sfv_t dup1, dup2;
+  dup1.push_back(make_pair("a", 1.0));
+  dup1.push_back(make_pair("b", 2.0));
+  dup2.push_back(make_pair("x", 1.0));
+  dup2.push_back(make_pair("y", 2.0));
+
+  this->light_lof_->clear();
+  EXPECT_TRUE(this->light_lof_->set_row("dummy_1", dup1));
+  EXPECT_TRUE(this->light_lof_->set_row("dummy_2", dup1));
+  EXPECT_TRUE(this->light_lof_->set_row("dummy_3", dup1));
+
+  for (int i = 0; i < (this->K - 1); ++i) {
+    EXPECT_TRUE(this->light_lof_->set_row(lexical_cast<string>(i) + "th_point", dup2));
+  }
+  EXPECT_FALSE(this->light_lof_->set_row("Kth_point", dup2));
 }
 
 TYPED_TEST_P(light_lof_test, config_validation) {
@@ -167,6 +187,7 @@ REGISTER_TYPED_TEST_CASE_P(
     name,
     get_all_row_ids,
     calc_anomaly_score_on_gaussian_random_samples,
+    ignore_kth_same_point,
     config_validation);
 
 INSTANTIATE_TYPED_TEST_CASE_P(

--- a/jubatus/core/anomaly/lof.cpp
+++ b/jubatus/core/anomaly/lof.cpp
@@ -117,9 +117,10 @@ void lof::update_row(const string& id, const sfv_diff_t& diff) {
   mixable_storage_->get_model()->update_row(id, diff);
 }
 
-void lof::set_row(const string& id, const common::sfv_t& sfv) {
+bool lof::set_row(const string& id, const common::sfv_t& sfv) {
   mixable_storage_->get_model()->remove_row(id);
   mixable_storage_->get_model()->update_row(id, sfv);
+  return true;
 }
 
 void lof::get_all_row_ids(vector<string>& ids) const {

--- a/jubatus/core/anomaly/lof.hpp
+++ b/jubatus/core/anomaly/lof.hpp
@@ -43,7 +43,7 @@ class lof : public anomaly_base {
   void clear();
   void clear_row(const std::string& id);
   void update_row(const std::string& id, const sfv_diff_t& diff);
-  void set_row(const std::string& id, const common::sfv_t& sfv);
+  bool set_row(const std::string& id, const common::sfv_t& sfv);
 
   void get_all_row_ids(std::vector<std::string>& ids) const;
   std::string type() const;

--- a/jubatus/core/driver/anomaly.cpp
+++ b/jubatus/core/driver/anomaly.cpp
@@ -88,8 +88,11 @@ float anomaly::overwrite(const string& id, const fv_converter::datum& d) {
   common::sfv_t v;
   converter_->convert_and_update_weight(d, v);
 
-  anomaly_->set_row(id, v);
-  return anomaly_->calc_anomaly_score(id);
+  if (anomaly_->set_row(id, v)) {
+    return anomaly_->calc_anomaly_score(id);
+  } else {
+    return anomaly_->calc_anomaly_score(v);
+  }
 }
 
 void anomaly::clear() {


### PR DESCRIPTION
This patch implements the idea proposed in #130.

When `ignore_kth_same_point` (which is a optional configuration defaults to false) is specified as true, nearest neighbor search runs before actually adding the data. If the distance to the (k-1) th neighbor is 0 (which means model already has (k-1) points that have the same feature vector as the data being added), reject adding new data to avoid LRD to go inf.

Note: we need to document this once this gets merged.