### PR TITLE
Fix code and wscript for cpplint.

### DIFF
--- a/jubatus/core/storage/bit_vector.hpp
+++ b/jubatus/core/storage/bit_vector.hpp
@@ -112,7 +112,7 @@ inline int bitcount(unsigned long long bits) {
 }
 
 template <class T>
-inline int bitcount(T); // = delete;
+inline int bitcount(T);  // = delete;
 
 }  // namespace detail
 

--- a/jubatus/core/storage/bit_vector.hpp
+++ b/jubatus/core/storage/bit_vector.hpp
@@ -80,11 +80,11 @@ inline int fast_bitcount(unsigned bits) {
   return __builtin_popcount(bits);
 }
 
-inline int fast_bitcount(unsigned long bits) {
+inline int fast_bitcount(unsigned long bits) {  // NOLINT
   return __builtin_popcountl(bits);
 }
 
-inline int fast_bitcount(unsigned long long bits) {
+inline int fast_bitcount(unsigned long long bits) {  // NOLINT
   return __builtin_popcountll(bits);
 }
 
@@ -103,11 +103,11 @@ inline int bitcount(unsigned bits) {
   return bitcount_dispatcher(bits);
 }
 
-inline int bitcount(unsigned long bits) {
+inline int bitcount(unsigned long bits) {  // NOLINT
   return bitcount_dispatcher(bits);
 }
 
-inline int bitcount(unsigned long long bits) {
+inline int bitcount(unsigned long long bits) {  // NOLINT
   return bitcount_dispatcher(bits);
 }
 

--- a/wscript
+++ b/wscript
@@ -136,7 +136,7 @@ def cpplint(ctx):
   tmp_file.flush()
   sys.stderr.write('Running cpplint...\n')
   ctx.exec_command('cat ' + tmp_file.name +
-                   ' | xargs "' + cpplint.abspath() + '" --filter=-runtime/references,-runtime/rtti,-runtime/int 2>&1' +
+                   ' | xargs "' + cpplint.abspath() + '" --filter=-runtime/references,-runtime/rtti 2>&1' +
                    ' | grep -v "^Done processing "')
   tmp_file.close()
 

--- a/wscript
+++ b/wscript
@@ -136,7 +136,7 @@ def cpplint(ctx):
   tmp_file.flush()
   sys.stderr.write('Running cpplint...\n')
   ctx.exec_command('cat ' + tmp_file.name +
-                   ' | xargs "' + cpplint.abspath() + '" --filter=-runtime/references,-runtime/rtti 2>&1' +
+                   ' | xargs "' + cpplint.abspath() + '" --filter=-runtime/references,-runtime/rtti,-runtime/int 2>&1' +
                    ' | grep -v "^Done processing "')
   tmp_file.close()
 


### PR DESCRIPTION
Fixed code and wscript for cpplint. It seems impossible to purge direct use of (unsigned) long (long), so I made `./waf cpplint` to ignore them.