### PR TITLE
Fix kmeans to throw exception in get_nearest_center when clustering is not performed

### DIFF
--- a/jubatus/core/clustering/kmeans_clustering_method.cpp
+++ b/jubatus/core/clustering/kmeans_clustering_method.cpp
@@ -102,6 +102,11 @@ vector<common::sfv_t> kmeans_clustering_method::get_k_center() const {
 
 int64_t kmeans_clustering_method::get_nearest_center_index(
     const common::sfv_t& point) const {
+  if (kcenters_.empty()) {
+    throw JUBATUS_EXCEPTION(common::exception::runtime_error(
+        "clustering is not performed yet"));
+  }
+
   return min_dist(point, kcenters_).first;
 }
 


### PR DESCRIPTION
Fixes https://github.com/jubatus/jubatus_core/issues/150.