### PR TITLE
Improve get status of classifier

### DIFF
--- a/jubatus/core/classifier/linear_classifier.cpp
+++ b/jubatus/core/classifier/linear_classifier.cpp
@@ -118,6 +118,10 @@ bool linear_classifier::set_label(const string& label) {
 void linear_classifier::get_status(std::map<string, string>& status) const {
   storage_->get_status(status);
   status["storage"] = storage_->type();
+
+  if (unlearner_) {
+    unlearner_->get_status(status);
+  }
 }
 
 void linear_classifier::update_weight(

--- a/jubatus/core/driver/classifier.cpp
+++ b/jubatus/core/driver/classifier.cpp
@@ -73,6 +73,7 @@ jubatus::core::classifier::classify_result classifier::classify(
 
 void classifier::get_status(std::map<string, string>& status) const {
   classifier_->get_status(status);
+  wm_.get_model()->get_status(status);
 }
 
 bool classifier::delete_label(const std::string& label) {

--- a/jubatus/core/fv_converter/counter.hpp
+++ b/jubatus/core/fv_converter/counter.hpp
@@ -82,6 +82,10 @@ class counter {
     }
   }
 
+  size_t size() const {
+    return data_.size();
+  }
+
   MSGPACK_DEFINE(data_);
 
   friend std::ostream& operator<<(std::ostream& os, const counter<T>& c) {

--- a/jubatus/core/fv_converter/keyword_weights.cpp
+++ b/jubatus/core/fv_converter/keyword_weights.cpp
@@ -15,9 +15,11 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include <cmath>
+#include <map>
 #include <string>
 #include <sstream>
 #include <utility>
+#include "jubatus/util/lang/cast.h"
 #include "../common/type.hpp"
 #include "datum_to_fv_converter.hpp"
 #include "keyword_weights.hpp"
@@ -93,6 +95,19 @@ string keyword_weights::to_string() const {
   }
   ss << " }";
   return ss.str();
+}
+
+void keyword_weights::get_status(
+    std::map<std::string, std::string>& status,
+    const std::string& prefix) const {
+  status[prefix + "_document_count"] =
+    jubatus::util::lang::lexical_cast<std::string>(
+        document_count_);
+  status[prefix + "_num_document_frequencies"] =
+    jubatus::util::lang::lexical_cast<std::string>(
+        document_frequencies_.size());
+  status[prefix + "_num_weights"] =
+    jubatus::util::lang::lexical_cast<std::string>(weights_.size());
 }
 
 }  // namespace fv_converter

--- a/jubatus/core/fv_converter/keyword_weights.hpp
+++ b/jubatus/core/fv_converter/keyword_weights.hpp
@@ -17,6 +17,7 @@
 #ifndef JUBATUS_CORE_FV_CONVERTER_KEYWORD_WEIGHTS_HPP_
 #define JUBATUS_CORE_FV_CONVERTER_KEYWORD_WEIGHTS_HPP_
 
+#include <map>
 #include <string>
 #include <msgpack.hpp>
 #include "jubatus/util/data/unordered_map.h"
@@ -52,6 +53,10 @@ class keyword_weights {
   MSGPACK_DEFINE(document_count_, document_frequencies_, weights_);
 
   std::string to_string() const;
+
+  void get_status(
+      std::map<std::string, std::string>& status,
+      const std::string& prefix) const;
 
  private:
   double get_global_weight(const std::string& key) const;

--- a/jubatus/core/fv_converter/weight_manager.cpp
+++ b/jubatus/core/fv_converter/weight_manager.cpp
@@ -117,6 +117,8 @@ void weight_manager::get_status(
   status["weight_manager_version"] =
     jubatus::util::lang::lexical_cast<std::string>(
         version_.get_number());
+  diff_weights_.get_status(status, "diff");
+  master_weights_.get_status(status, "master");
 }
 
 }  // namespace fv_converter

--- a/jubatus/core/fv_converter/weight_manager.cpp
+++ b/jubatus/core/fv_converter/weight_manager.cpp
@@ -19,6 +19,7 @@
 #include <cmath>
 #include <string>
 #include <utility>
+#include <map>
 #include "../common/type.hpp"
 #include "datum_to_fv_converter.hpp"
 #include "jubatus/util/concurrent/lock.h"
@@ -108,6 +109,14 @@ double weight_manager::get_global_weight(const std::string& key) const {
 void weight_manager::add_weight(const std::string& key, float weight) {
   scoped_lock lk(mutex_);
   diff_weights_.add_weight(key, weight);
+}
+
+void weight_manager::get_status(
+    std::map<std::string, std::string>& status) const {
+  scoped_lock lk(mutex_);
+  status["weight_manager_version"] =
+    jubatus::util::lang::lexical_cast<std::string>(
+        version_.get_number());
 }
 
 }  // namespace fv_converter

--- a/jubatus/core/fv_converter/weight_manager.hpp
+++ b/jubatus/core/fv_converter/weight_manager.hpp
@@ -21,6 +21,7 @@
 #include <ostream>
 #include <sstream>
 #include <string>
+#include <map>
 #include <msgpack.hpp>
 #include "jubatus/util/data/unordered_map.h"
 #include "jubatus/util/concurrent/mutex.h"
@@ -113,6 +114,8 @@ class weight_manager : public framework::model {
        << " master_weights:" << master_weights_.to_string();
     return ss.str();
   }
+
+  void get_status(std::map<std::string, std::string>& status) const;
 
  private:
   uint64_t get_document_count() const {

--- a/jubatus/core/storage/local_storage_mixture.cpp
+++ b/jubatus/core/storage/local_storage_mixture.cpp
@@ -224,6 +224,8 @@ void local_storage_mixture::get_status(
       class2id_.size());
   status["diff_size"] =
     jubatus::util::lang::lexical_cast<std::string>(tbl_diff_.size());
+  status["model_version"] = jubatus::util::lang::lexical_cast<std::string>(
+      model_version_.get_number());
 }
 
 void local_storage_mixture::update(

--- a/jubatus/core/unlearner/lru_unlearner.cpp
+++ b/jubatus/core/unlearner/lru_unlearner.cpp
@@ -17,6 +17,7 @@
 #include "lru_unlearner.hpp"
 
 #include <string>
+#include <map>
 #include "jubatus/util/data/unordered_set.h"
 
 // TODO(kmaehashi) move key_matcher to common
@@ -133,6 +134,14 @@ void lru_unlearner::rebuild_entry_map() {
   for (lru::iterator it = lru_.begin(); it != lru_.end(); ++it) {
     entry_map_[*it] = it;
   }
+}
+
+void lru_unlearner::get_status(
+    std::map<std::string, std::string>& status) const {
+  status["num_unlearner_unlearned_ids"] =
+    jubatus::util::lang::lexical_cast<std::string>(entry_map_.size());
+  status["num_unlearner_sticky_ids"] =
+    jubatus::util::lang::lexical_cast<std::string>(sticky_ids_.size());
 }
 
 }  // namespace unlearner

--- a/jubatus/core/unlearner/lru_unlearner.hpp
+++ b/jubatus/core/unlearner/lru_unlearner.hpp
@@ -20,6 +20,7 @@
 #include <stdint.h>
 #include <list>
 #include <string>
+#include <map>
 #include "jubatus/util/data/serialization.h"
 #include "jubatus/util/data/unordered_map.h"
 #include "jubatus/util/data/unordered_set.h"
@@ -63,6 +64,7 @@ class lru_unlearner : public unlearner_base {
   bool touch(const std::string& id);
   bool remove(const std::string& id);
   bool exists_in_memory(const std::string& id) const;
+  void get_status(std::map<std::string, std::string>& status) const;
 
  private:
   typedef std::list<std::string> lru;

--- a/jubatus/core/unlearner/random_unlearner.cpp
+++ b/jubatus/core/unlearner/random_unlearner.cpp
@@ -17,6 +17,7 @@
 #include "random_unlearner.hpp"
 
 #include <string>
+#include <map>
 #include <limits>
 #include "../common/exception.hpp"
 
@@ -91,6 +92,12 @@ bool random_unlearner::remove(const std::string& id) {
 
 bool random_unlearner::exists_in_memory(const std::string& id) const {
   return id_map_.count(id) > 0;
+}
+
+void random_unlearner::get_status(
+    std::map<std::string, std::string>& status) const {
+  status["num_unlearner_ids"] =
+    jubatus::util::lang::lexical_cast<std::string>(ids_.size());
 }
 
 }  // namespace unlearner

--- a/jubatus/core/unlearner/random_unlearner.hpp
+++ b/jubatus/core/unlearner/random_unlearner.hpp
@@ -19,6 +19,7 @@
 
 #include <string>
 #include <vector>
+#include <map>
 #include "jubatus/util/data/optional.h"
 #include "jubatus/util/data/serialization.h"
 #include "jubatus/util/data/unordered_map.h"
@@ -57,6 +58,7 @@ class random_unlearner : public unlearner_base {
   bool touch(const std::string& id);
   bool remove(const std::string& id);
   bool exists_in_memory(const std::string& id) const;
+  void get_status(std::map<std::string, std::string>& status) const;
 
  private:
   /**

--- a/jubatus/core/unlearner/unlearner_base.hpp
+++ b/jubatus/core/unlearner/unlearner_base.hpp
@@ -18,6 +18,7 @@
 #define JUBATUS_CORE_UNLEARNER_UNLEARNER_BASE_HPP_
 
 #include <string>
+#include <map>
 #include "jubatus/util/lang/function.h"
 
 namespace jubatus {
@@ -42,6 +43,7 @@ class unlearner_base {
 
   virtual std::string type() const = 0;
   virtual void clear() = 0;
+  virtual void get_status(std::map<std::string, std::string>& status) const = 0;
 
   // Tests if the given id can be touched.
   //

--- a/jubatus/core/unlearner/unlearner_base_test.cpp
+++ b/jubatus/core/unlearner/unlearner_base_test.cpp
@@ -15,6 +15,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include <string>
+#include <map>
 #include <gtest/gtest.h>
 #include "test_util.hpp"
 #include "unlearner_base.hpp"
@@ -30,6 +31,8 @@ class mock_unlearner : public unlearner_base {
     return "mock_unlearner";
   }
   void clear() {
+  }
+  void get_status(std::map<std::string, std::string>& status) const {
   }
 
   bool can_touch(const std::string& id) {


### PR DESCRIPTION
We added the following values to get_status of classifier.

* unlearner
  * random_unlearner

    * ``num_unlearner_ids``: The number of IDs that have stored
  * lru_unlearner

     * ``num_unlearner_unlearned_ids``: The number of IDs that have stored (exclude sticky_ids)
     * ``num_unlearner_sticky_ids``: The number of sticky IDs that have stored
* weight_manager

   * ``weight_manager_version``: The version number of weight_manager
  * ``master_document_count``: The number of documents that have stored in master area
  * ``diff_document_count``: The number of documents that have stored in diff area
  * ``master_num_document_frequencies``: The number of features that have stored in master area
  * ``diff_num_document_frequencies``: The number of features that have stored in diff area
  * ``master_num_weights``: The number of features that have stored in master area
  * ``diff_num_weights``: The number of features that have stored in diff area
* storage (local_storage_mixture)

  * ``model_version``: The version of model

Next, we should add these to other engines.