### PR TITLE
fix clustering storage to exclude name from serialization (fix #70)

### DIFF
--- a/jubatus/core/clustering/storage.cpp
+++ b/jubatus/core/clustering/storage.cpp
@@ -56,6 +56,7 @@ void storage::get_diff(diff_t& d) const {
 bool storage::put_diff(const diff_t& diff) {
   common_.clear();
   for (diff_t::const_iterator it = diff.begin(); it != diff.end(); ++it) {
+    // Exclude data originated from me.
     if (it->first != name_) {
       common_.push_back(*it);
     }

--- a/jubatus/core/clustering/storage.hpp
+++ b/jubatus/core/clustering/storage.hpp
@@ -61,7 +61,7 @@ class storage : public event_dispatcher<storage_event_type, wplist> {
   void unpack(msgpack::object o);
   void clear();
 
-  MSGPACK_DEFINE(revision_, name_, config_, common_);
+  MSGPACK_DEFINE(revision_, config_, common_);
 
  protected:
   void increment_revision();


### PR DESCRIPTION
Fix #70; now clustering MIX works properly.

Each clustering instance (in jubatus_core layer) have its own identifier to distinguish itself in cluster.  The ID is generated and assigned by jubatus_server layer in format of "IP_PORT" (e.g., ``10.0.0.1_9199``.)
(Note: see https://github.com/jubatus/jubatus/pull/1041 for ID generation spec.)

In the clustering instance, however, the ID is marked to be serialized (i.e., [listed in MSGPACK_DEFINE](https://github.com/jubatus/jubatus_core/blob/0.2.1/jubatus/core/clustering/storage.hpp#L64)).  After a model recovery phase (which always runs when new server joins to an existing cluster), an ID of the first instance in the cluster will be copied over to the newly-joined instance.  As a result, every instance in the cluster will have the same ID.  By design of clustering MIX, data points that match with the its own ID will be [ignored during put_diff](https://github.com/jubatus/jubatus_core/blob/0.2.1/jubatus/core/clustering/storage.cpp#L59-L61)); so MIX data is exchanged but everything was discarded in put_diff.

This patch solves the problem by excluding ID from storage serialization.