### PR TITLE
fix clustering interface to accept externally specified seed (fix #176)

### DIFF
--- a/jubatus/core/clustering/clustering_config.hpp
+++ b/jubatus/core/clustering/clustering_config.hpp
@@ -35,7 +35,8 @@ struct clustering_config {
         bicriteria_base_size(10),
         compressed_bucket_size(200),
         forgetting_factor(2.0),
-        forgetting_threshold(0.05) {
+        forgetting_threshold(0.05),
+        seed(0) {
   }
 
   int k;
@@ -48,6 +49,7 @@ struct clustering_config {
   int compressed_bucket_size;
   double forgetting_factor;
   double forgetting_threshold;
+  int64_t seed;
 
   MSGPACK_DEFINE(
       k,
@@ -57,7 +59,8 @@ struct clustering_config {
       bicriteria_base_size,
       compressed_bucket_size,
       forgetting_factor,
-      forgetting_threshold);
+      forgetting_threshold,
+      seed);
 
   template<typename Ar>
   void serialize(Ar& ar) {
@@ -68,7 +71,8 @@ struct clustering_config {
         & JUBA_MEMBER(bicriteria_base_size)
         & JUBA_MEMBER(compressed_bucket_size)
         & JUBA_MEMBER(forgetting_factor)
-        & JUBA_MEMBER(forgetting_threshold);
+        & JUBA_MEMBER(forgetting_threshold)
+        & JUBA_MEMBER(seed);
   }
 };
 

--- a/jubatus/core/clustering/clustering_method_factory.cpp
+++ b/jubatus/core/clustering/clustering_method_factory.cpp
@@ -36,11 +36,11 @@ shared_ptr<clustering_method> clustering_method_factory::create(
     const clustering_config& config) {
   if (method == "kmeans") {
     return shared_ptr<clustering_method>(
-        new kmeans_clustering_method(config.k));
+        new kmeans_clustering_method(config.k, config.seed));
 #ifdef JUBATUS_USE_EIGEN
   } else if (method == "gmm") {
     return shared_ptr<clustering_method>(
-        new gmm_clustering_method(config.k));
+        new gmm_clustering_method(config.k, config.seed));
 #endif
   }
   throw JUBATUS_EXCEPTION(core::common::unsupported_method(method));

--- a/jubatus/core/clustering/gmm.cpp
+++ b/jubatus/core/clustering/gmm.cpp
@@ -36,13 +36,14 @@ namespace jubatus {
 namespace core {
 namespace clustering {
 
-gmm::gmm()
-    : rand_(0) {
+gmm::gmm(uint32_t seed)
+    : seed_(seed),
+      rand_(seed) {
 }
 
 void gmm::batch(const eigen_wsvec_list_t& data, int d, int k) {
   if (data.empty()) {
-    *this = gmm();
+    *this = gmm(seed_);
     return;
   }
 

--- a/jubatus/core/clustering/gmm.hpp
+++ b/jubatus/core/clustering/gmm.hpp
@@ -27,7 +27,7 @@ namespace clustering {
 
 class gmm {
  public:
-  gmm();
+  explicit gmm(uint32_t seed);
 
   void batch(const eigen_wsvec_list_t& data, int d, int k);
   eigen_svec_list_t get_centers() {
@@ -58,6 +58,7 @@ class gmm {
   eigen_solver_list_t cov_solvers_;
   int d_;
   int k_;
+  int seed_;
 
   jubatus::util::math::random::mtrand rand_;
 };

--- a/jubatus/core/clustering/gmm_clustering_method.cpp
+++ b/jubatus/core/clustering/gmm_clustering_method.cpp
@@ -27,8 +27,8 @@ namespace jubatus {
 namespace core {
 namespace clustering {
 
-gmm_clustering_method::gmm_clustering_method(size_t k)
-    : k_(k), kcenters_(), mapper_(), gmm_() {
+gmm_clustering_method::gmm_clustering_method(size_t k, uint32_t seed)
+    : k_(k), seed_(seed), kcenters_(), mapper_(), gmm_(seed) {
 }
 
 gmm_clustering_method::~gmm_clustering_method() {
@@ -36,7 +36,7 @@ gmm_clustering_method::~gmm_clustering_method() {
 
 void gmm_clustering_method::batch_update(wplist points) {
   if (points.empty()) {
-    *this = gmm_clustering_method(k_);
+    *this = gmm_clustering_method(k_, seed_);
     return;
   }
   mapper_.clear();

--- a/jubatus/core/clustering/gmm_clustering_method.hpp
+++ b/jubatus/core/clustering/gmm_clustering_method.hpp
@@ -30,7 +30,7 @@ namespace clustering {
 
 class gmm_clustering_method : public clustering_method {
  public:
-  explicit gmm_clustering_method(size_t k);
+  gmm_clustering_method(size_t k, uint32_t seed);
   ~gmm_clustering_method();
 
   void batch_update(wplist points);
@@ -43,6 +43,7 @@ class gmm_clustering_method : public clustering_method {
 
  private:
   size_t k_;
+  uint32_t seed_;
   std::vector<common::sfv_t> kcenters_;
   eigen_feature_mapper mapper_;
   gmm gmm_;

--- a/jubatus/core/clustering/gmm_test.cpp
+++ b/jubatus/core/clustering/gmm_test.cpp
@@ -34,7 +34,7 @@ class gmm_test : public ::testing::Test {
   gmm_test() : r_(0) {}
 
   virtual void SetUp() {
-    gmm_.reset(new gmm);
+    gmm_.reset(new gmm(0));
   }
 
   void do_batch(size_t num) {

--- a/jubatus/core/clustering/kmeans_clustering_method.cpp
+++ b/jubatus/core/clustering/kmeans_clustering_method.cpp
@@ -29,9 +29,10 @@ namespace jubatus {
 namespace core {
 namespace clustering {
 
-kmeans_clustering_method::kmeans_clustering_method(size_t k)
+kmeans_clustering_method::kmeans_clustering_method(size_t k, uint32_t seed)
     : k_(k),
-      rand_(0) {
+      seed_(seed),
+      rand_(seed) {
 }
 
 kmeans_clustering_method::~kmeans_clustering_method() {

--- a/jubatus/core/clustering/kmeans_clustering_method.hpp
+++ b/jubatus/core/clustering/kmeans_clustering_method.hpp
@@ -28,7 +28,7 @@ namespace clustering {
 
 class kmeans_clustering_method : public clustering_method {
  public:
-  explicit kmeans_clustering_method(size_t k);
+  explicit kmeans_clustering_method(size_t k, uint32_t seed);
   ~kmeans_clustering_method();
 
   void batch_update(wplist points);
@@ -45,6 +45,7 @@ class kmeans_clustering_method : public clustering_method {
 
   std::vector<common::sfv_t> kcenters_;
   size_t k_;
+  uint32_t seed_;
 
   jubatus::util::math::random::mtrand rand_;
 };

--- a/jubatus/core/clustering/kmeans_compressor.cpp
+++ b/jubatus/core/clustering/kmeans_compressor.cpp
@@ -106,7 +106,7 @@ void bicriteria_as_coreset(
 
 kmeans_compressor::kmeans_compressor(const clustering_config& cfg)
   : compressor(cfg),
-    rand_(0) {
+    rand_(cfg.seed) {
 }
 
 kmeans_compressor::~kmeans_compressor() {


### PR DESCRIPTION
Exposes a seed of clustering as a configuration parameter; fix #176.
This patch adds new configuration parameter `seed` (uint32_t) which is used as a seed in mtrand.