### PR TITLE
improve nearest_neighbor performance and bugs

### DIFF
--- a/jubatus/core/nearest_neighbor/nearest_neighbor_base.cpp
+++ b/jubatus/core/nearest_neighbor/nearest_neighbor_base.cpp
@@ -21,6 +21,7 @@
 #include "exception.hpp"
 #include "nearest_neighbor_base.hpp"
 #include "../storage/column_table.hpp"
+#include "jubatus/util/concurrent/rwmutex.h"
 
 using std::pair;
 using std::string;
@@ -42,22 +43,24 @@ nearest_neighbor_base::nearest_neighbor_base(
 void nearest_neighbor_base::get_all_row_ids(vector<string>& ids) const {
   vector<string> ret;
   shared_ptr<const storage::column_table> table = get_const_table();
+  util::concurrent::scoped_rlock lk(table->get_mutex());
+
   ret.reserve(table->size());
   for (size_t i = 0; i < table->size(); ++i) {
-    ret.push_back(table->get_key(i));
+    ret.push_back(table->get_key_nolock(i));
   }
   ret.swap(ids);
 }
 
 void nearest_neighbor_base::clear() {
-  mixable_table_->get_model()->clear();
+  mixable_table_->get_model()->clear();  // lock acquired inside
 }
 
 void nearest_neighbor_base::similar_row(
     const common::sfv_t& query,
     vector<pair<string, float> >& ids,
     uint64_t ret_num) const {
-  neighbor_row(query, ids, ret_num);
+  neighbor_row(query, ids, ret_num);  // lock acquired inside
   for (size_t i = 0; i < ids.size(); ++i) {
     ids[i].second = calc_similarity(ids[i].second);
   }
@@ -67,18 +70,18 @@ void nearest_neighbor_base::similar_row(
     const string& query_id,
     vector<pair<string, float> >& ids,
     uint64_t ret_num) const {
-  neighbor_row(query_id, ids, ret_num);
+  neighbor_row(query_id, ids, ret_num);  // lock acquired inside
   for (size_t i = 0; i < ids.size(); ++i) {
     ids[i].second = calc_similarity(ids[i].second);
   }
 }
 
 void nearest_neighbor_base::pack(framework::packer& packer) const {
-  get_const_table()->pack(packer);
+  get_const_table()->pack(packer);  // lock acquired inside
 }
 
 void nearest_neighbor_base::unpack(msgpack::object o) {
-  get_table()->unpack(o);
+  get_table()->unpack(o);  // lock acquired inside
 }
 
 framework::mixable* nearest_neighbor_base::get_mixable() const {

--- a/jubatus/core/storage/bit_vector.hpp
+++ b/jubatus/core/storage/bit_vector.hpp
@@ -74,7 +74,7 @@ struct bitcount_impl<T, 8> {
   }
 };
 
-#ifdef __GNUG__
+#ifdef __POPCNT__
 
 inline int fast_bitcount(unsigned bits) {
   return __builtin_popcount(bits);
@@ -92,7 +92,7 @@ inline int fast_bitcount(unsigned long long bits) {  // NOLINT
 
 template <class T>
 inline int bitcount_dispatcher(T bits) {
-#ifdef __GNUG__
+#ifdef __POPCNT__
   return fast_bitcount(bits);
 #else
   return bitcount_impl<T, sizeof(T)>::call(bits);

--- a/jubatus/core/storage/column_table.hpp
+++ b/jubatus/core/storage/column_table.hpp
@@ -373,10 +373,12 @@ class column_table {
   MSGPACK_DEFINE(keys_, tuples_, versions_, columns_, clock_, index_);
 
   void pack(framework::packer& packer) const {
+    jubatus::util::concurrent::scoped_rlock lk(table_lock_);
     packer.pack(*this);
   }
 
   void unpack(msgpack::object o) {
+    jubatus::util::concurrent::scoped_wlock lk(table_lock_);
     o.convert(this);
   }
 

--- a/wscript
+++ b/wscript
@@ -39,7 +39,7 @@ def options(opt):
 def configure(conf):
   env = conf.env
 
-  env.append_unique('CXXFLAGS', ['-O2', '-Wall', '-g', '-pipe', '-fno-omit-frame-pointer', '-pthread'])
+  env.append_unique('CXXFLAGS', ['-O2', '-Wall', '-g', '-pipe', '-fno-omit-frame-pointer', '-pthread', '-msse4.2'])
 
   conf.load('compiler_cxx')
   conf.load('unittest_gtest')


### PR DESCRIPTION
I tried several enhancement on `nearest_neighbor`

- `hash()` is heavy so that it should be done out of model's lock.
- lock was not taken in some methods(`pack`/`unpack`)
- `get_all_row_ids` should get lock just once.
- `__GNUG__` macro should be replaced by `__POPCNT__` for performance improvement.