### PR TITLE
Improve bit_vector::is_empty performance (fix #191)

### DIFF
--- a/jubatus/core/storage/bit_vector.hpp
+++ b/jubatus/core/storage/bit_vector.hpp
@@ -261,8 +261,21 @@ struct bit_vector_base {
     }
     return bits_[pos / BASE_BITS] & (1LLU << (pos % BASE_BITS));
   }
+
+  /**
+   * Returns true if all the bits in this vector are 0.
+   * If this vector is not initialized yet, returns true.
+   */
   bool is_empty() const {
-    return bit_count() == 0;
+    if (bits_ == NULL) {
+      return true;
+    }
+    for (int64_t i = (used_bytes() / sizeof(bit_base)) - 1; i >= 0; --i) {
+      if (bits_[i] != 0) {
+        return false;
+      }
+    }
+    return true;
   }
 
   void clear() {


### PR DESCRIPTION
Fixes #191.

I did a simple micro benchmark for this patch for 3 times.
I saw roughly 2x speed up for empty bit_vector and 33x for non-empty bit_vector.

https://github.com/kmaehashi/sandbox/blob/master/jubatus/bit_vector_performance/test.cpp

Before applying this patch:

```
empty vector: took 60000
non-empty vector: took 3690000

empty vector: took 50000
non-empty vector: took 3710000

empty vector: took 50000
non-empty vector: took 3690000
```

After applying this patch:

```
empty vector: took 30000
non-empty vector: took 110000

empty vector: took 30000
non-empty vector: took 110000

empty vector: took 30000
non-empty vector: took 110000
```