### PR TITLE
remove unnecessary bit_vector::is_empty call (fix #192)

### DIFF
--- a/jubatus/core/storage/bit_vector.hpp
+++ b/jubatus/core/storage/bit_vector.hpp
@@ -273,6 +273,11 @@ struct bit_vector_base {
   uint64_t calc_hamming_similarity(const bit_vector_base& bv) const {
     return bit_num() - calc_hamming_distance(bv);
   }
+
+  /**
+   * Returns hamming distance between this vector and given vector.
+   * Uninitialized vectors are considered as zero-initialized.
+   */
   uint64_t calc_hamming_distance(const bit_vector_base& bv) const {
     if (bit_num() != bv.bit_num()) {
       throw bit_vector_unmatch_exception(
@@ -280,11 +285,9 @@ struct bit_vector_base {
           jubatus::util::lang::lexical_cast<std::string>(bit_num()) + " with " +
           jubatus::util::lang::lexical_cast<std::string>(bv.bit_num()));
     }
-    if (is_empty() && bv.is_empty()) {
-      return 0;
-    } else if (is_empty()) {
+    if (bits_ == NULL) {
       return bv.bit_count();
-    } else if (bv.is_empty()) {
+    } else if (bv.bits_ == NULL) {
       return bit_count();
     }
     size_t match_num = 0;


### PR DESCRIPTION
Fixes #192.

I did a simple micro benchmark for this patch for 3 times.
I saw a slight improvements for non-empty bit_vector.
Although #193 made `is_empty` much faster, taking the fact that almost every vectors being not empty in Jubatus use cases into consideration, it is still meaningful to apply this patch, as the benchmark result shows.

https://github.com/kmaehashi/sandbox/blob/master/jubatus/bit_vector_performance/test_hamming.cpp


As of v0.2.3:

```
empty vector: took 20000
non-empty vector: took 1570000

empty vector: took 10000
non-empty vector: took 1570000

empty vector: took 20000
non-empty vector: took 1570000
```

After applying #193:

```
empty vector: took 10000
non-empty vector: took 490000

empty vector: took 10000
non-empty vector: took 490000

empty vector: took 10000
non-empty vector: took 490000
```

After applying #193 and this patch:

```
empty vector: took 10000
non-empty vector: took 450000

empty vector: took 10000
non-empty vector: took 450000

empty vector: took 10000
non-empty vector: took 460000
```