### PR TITLE
Fix bit vector bug

### DIFF
--- a/jubatus/core/storage/bit_vector.hpp
+++ b/jubatus/core/storage/bit_vector.hpp
@@ -171,7 +171,7 @@ struct bit_vector_base {
     }
   }
 
-  void resize_and_clear(uint64_t bit_num) {
+  void resize_and_clear(size_t bit_num) {
     release();
     own_ = false;
     bit_num_ = bit_num;

--- a/jubatus/core/storage/bit_vector.hpp
+++ b/jubatus/core/storage/bit_vector.hpp
@@ -284,7 +284,7 @@ struct bit_vector_base {
     if (bits_ == NULL) {
       return true;
     }
-    for (int64_t i = (used_bytes() / sizeof(bit_base)) - 1; i >= 0; --i) {
+    for (size_t i = 0, blocks = used_bytes() / sizeof(bit_base); i < blocks; ++i) {
       if (bits_[i] != 0) {
         return false;
       }
@@ -318,7 +318,7 @@ struct bit_vector_base {
       return bit_count();
     }
     size_t match_num = 0;
-    for (size_t i = 0; i < used_bytes() / sizeof(bit_base); ++i) {
+    for (size_t i = 0, blocks = used_bytes() / sizeof(bit_base); i < blocks; ++i) {
       match_num += detail::bitcount(bits_[i] ^ bv.bits_[i]);
     }
     return match_num;
@@ -328,7 +328,7 @@ struct bit_vector_base {
       return 0;
     }
     size_t result = 0;
-    for (int64_t i = (used_bytes() / sizeof(bit_base)) - 1; i >= 0; --i) {
+    for (size_t i = 0, blocks = used_bytes() / sizeof(bit_base); i < blocks; ++i) {
       result += detail::bitcount(bits_[i]);
     }
     return result;

--- a/jubatus/core/storage/bit_vector.hpp
+++ b/jubatus/core/storage/bit_vector.hpp
@@ -226,13 +226,20 @@ struct bit_vector_base {
     if (bits_ == NULL) {
       return;
     }
+    if (bit_num_ <= pos) {
+      throw bit_vector_unmatch_exception(
+          "clear_bit(): invalid posison " +
+          jubatus::util::lang::lexical_cast<std::string>(pos) +
+          " for length: " +
+          jubatus::util::lang::lexical_cast<std::string>(bit_num_));
+    }
     bits_[pos / BASE_BITS] &= ~(1LLU << (pos % BASE_BITS));
   }
   void set_bit(size_t pos) {
     if (bits_ == NULL) {
       alloc_memory();
     }
-    if (static_cast<size_t>(bit_num_) < pos) {
+    if (bit_num_ <= pos) {
       throw bit_vector_unmatch_exception(
           "set_bit(): invalid posison " +
           jubatus::util::lang::lexical_cast<std::string>(pos) +
@@ -258,6 +265,13 @@ struct bit_vector_base {
   bool get_bit(size_t pos) const {
     if (bits_ == NULL) {
       return false;
+    }
+    if (bit_num_ <= pos) {
+      throw bit_vector_unmatch_exception(
+          "get_bit(): invalid posison " +
+          jubatus::util::lang::lexical_cast<std::string>(pos) +
+          " for length: " +
+          jubatus::util::lang::lexical_cast<std::string>(bit_num_));
     }
     return bits_[pos / BASE_BITS] & (1LLU << (pos % BASE_BITS));
   }

--- a/jubatus/core/storage/bit_vector_test.cpp
+++ b/jubatus/core/storage/bit_vector_test.cpp
@@ -28,12 +28,36 @@ TEST(bit_vector, length) {
   EXPECT_EQ(bv.bit_num(), 80U);
 }
 
+TEST(bit_vector, bounds_checking) {
+  bit_vector bv(80);
+
+  // reading/writing out-of-bound bits should throw exception
+  EXPECT_THROW(bv.set_bit(bv.bit_num()),
+               jubatus::core::storage::bit_vector_unmatch_exception);
+  EXPECT_THROW(bv.get_bit(bv.bit_num()),
+               jubatus::core::storage::bit_vector_unmatch_exception);
+  EXPECT_THROW(bv.reverse_bit(bv.bit_num()),
+               jubatus::core::storage::bit_vector_unmatch_exception);
+  EXPECT_THROW(bv.clear_bit(bv.bit_num()),
+               jubatus::core::storage::bit_vector_unmatch_exception);
+
+  // writing bits for uninitialized vector should throw exception
+  // get_bit/clear_bit should do nothing for uninitialized vector
+  EXPECT_THROW(bit_vector().set_bit(0),
+               jubatus::core::storage::bit_vector_unmatch_exception);
+  EXPECT_NO_THROW(bit_vector().get_bit(0));
+  EXPECT_THROW(bit_vector().reverse_bit(0),
+               jubatus::core::storage::bit_vector_unmatch_exception);
+  EXPECT_NO_THROW(bit_vector().clear_bit(0));
+}
+
 TEST(bit_vector, set) {
   bit_vector bv(80);
   for (size_t i = 0; i < bv.bit_num(); ++i) {
     bv.set_bit(i);
   }
 }
+
 TEST(bit_vector, is_empty) {
   bit_vector bv(80);
   ASSERT_TRUE(bv.is_empty());
@@ -41,6 +65,9 @@ TEST(bit_vector, is_empty) {
   ASSERT_FALSE(bv.is_empty());
   bv.clear_bit(4);
   ASSERT_TRUE(bv.is_empty());
+
+  // uninitialized bit_vectors must be empty
+  ASSERT_TRUE(bit_vector().is_empty());
 }
 
 TEST(bit_vector, set_get) {


### PR DESCRIPTION
This PR fixes various bugs (as follows) in bit_vector.  Please note that these bugs do NOT affect the Jubatus functionality, however they may cause unit test failures. It may also become a issue for developers reusing bit_vector in their original Jubatus engine.

* Fixed illegal out-of-bound array access in `is_empty` and `bit_count` methods. This only occurs when the length of bit_vector is 0-bit.  The similar loop condition in `calc_hamming_distance` method is also fixed for performance. This fixes `bit_index_storage_test` test failures (that was observed under 32-bit environment.)
* Fixed bounds checking of `pos` (bit position) argument in `clear_bit`, `set_bit` and `get_bit` methods. Tests are added for these edge cases. Related to #170.
* Fixed signature of `resize_and_clear` method to avoid overflow in non 64-bit environment.