### PR TITLE
fix double acquisition of read lock (fix #199)

### DIFF
--- a/jubatus/core/nearest_neighbor/bit_vector_nearest_neighbor_base.cpp
+++ b/jubatus/core/nearest_neighbor/bit_vector_nearest_neighbor_base.cpp
@@ -72,6 +72,9 @@ void bit_vector_nearest_neighbor_base::neighbor_row(
     uint64_t ret_num) const {
   const bit_vector query_hash = hash(query);
   util::concurrent::scoped_rlock lk(get_const_table()->get_mutex());
+
+  /* table lock acquired; all subsequent table operations must be nolock */
+
   neighbor_row_from_hash(query_hash, ids, ret_num);
 }
 
@@ -80,8 +83,11 @@ void bit_vector_nearest_neighbor_base::neighbor_row(
     vector<pair<string, float> >& ids,
     uint64_t ret_num) const {
   util::concurrent::scoped_rlock lk(get_const_table()->get_mutex());
+
+  /* table lock acquired; all subsequent table operations must be nolock */
+
   const storage::column_table& table = *get_const_table();
-  const pair<bool, uint64_t> maybe_index = table.exact_match(query_id);
+  const pair<bool, uint64_t> maybe_index = table.exact_match_nolock(query_id);
   if (!maybe_index.first) {
     ids.clear();
     return;

--- a/jubatus/core/nearest_neighbor/nearest_neighbor_base.cpp
+++ b/jubatus/core/nearest_neighbor/nearest_neighbor_base.cpp
@@ -45,8 +45,11 @@ void nearest_neighbor_base::get_all_row_ids(vector<string>& ids) const {
   shared_ptr<const storage::column_table> table = get_const_table();
   util::concurrent::scoped_rlock lk(table->get_mutex());
 
-  ret.reserve(table->size());
-  for (size_t i = 0; i < table->size(); ++i) {
+  /* table lock acquired; all subsequent table operations must be nolock */
+
+  uint64_t table_size = table->size_nolock();
+  ret.reserve(table_size);
+  for (size_t i = 0; i < table_size; ++i) {
     ret.push_back(table->get_key_nolock(i));
   }
   ret.swap(ids);

--- a/jubatus/core/storage/column_table.cpp
+++ b/jubatus/core/storage/column_table.cpp
@@ -60,6 +60,11 @@ void column_table::clear() {
 std::pair<bool, uint64_t> column_table::exact_match(
     const std::string& prefix) const {
   jutil::concurrent::scoped_rlock lk(table_lock_);
+  return exact_match_nolock(prefix);
+}
+
+std::pair<bool, uint64_t> column_table::exact_match_nolock(
+    const std::string& prefix) const {
   index_table::const_iterator it = index_.find(prefix);
   if (it == index_.end()) {
     return std::make_pair(false, 0LLU);

--- a/jubatus/core/storage/column_table.hpp
+++ b/jubatus/core/storage/column_table.hpp
@@ -205,6 +205,10 @@ class column_table {
 
   uint64_t size() const {
     jubatus::util::concurrent::scoped_rlock lk(table_lock_);
+    return size_nolock();
+  }
+
+  uint64_t size_nolock() const {
     return tuples_;
   }
 
@@ -216,6 +220,8 @@ class column_table {
   }
 
   std::pair<bool, uint64_t> exact_match(const std::string& prefix) const;
+  std::pair<bool, uint64_t> exact_match_nolock(
+      const std::string& prefix) const;
 
   friend std::ostream& operator<<(std::ostream& os, const column_table& tbl) {
     jubatus::util::concurrent::scoped_rlock lk(tbl.table_lock_);


### PR DESCRIPTION
Fix #199.

As pthread mutexes are reentrant and acquisition of read locks are blocked when acquisition of write lock is being blocked, for two threads T1 and T2:

1. T1 tries to acquire read lock => success
2. T2 tries to acquire write lock => blocked (wait for the lock 1. to be released)
3. T1 tries to acquire read lock (again, before releasing 1.) => blocked (wait for the lock 2. to be acquired & released)

... so T1 and T2 deadlocks.

When deadlocked, you'll see that two threads are stuck in this way:

```
(gdb) info threads
  Id   Target Id         Frame
  4    Thread 0x7feefc4f5700 (LWP 20293) "jubanearest_nei" do_sigwait (set=<optimized out>, sig=0x7feefc4f4df8) at ../nptl/sysdeps/unix/sysv/linux/../../../../../sysdeps/unix/sysv/linux/sigwait.c:65
  3    Thread 0x7feefbcf4700 (LWP 20294) "jubanearest_nei" pthread_rwlock_rdlock () at ../nptl/sysdeps/unix/sysv/linux/x86_64/pthread_rwlock_rdlock.S:85
  2    Thread 0x7feefb4f3700 (LWP 20295) "jubanearest_nei" pthread_rwlock_wrlock () at ../nptl/sysdeps/unix/sysv/linux/x86_64/pthread_rwlock_wrlock.S:83
* 1    Thread 0x7fef015b3780 (LWP 20284) "jubanearest_nei" 0x00007feefe869148 in pthread_join (threadid=140664403609344, thread_return=0x7fffb0805a10) at pthread_join.c:89
```

This behavior of pthread mutex is documented in the reference: http://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_rwlock_rdlock.html

```
The pthread_rwlock_rdlock() function shall apply a read lock to the read-write lock referenced by rwlock. The calling thread acquires the read lock if a writer does not hold the lock and there are no writers blocked on the lock.
```