### PR TITLE
fix null checking of ignore_kth_same_point in anomaly

### DIFF
--- a/jubatus/core/anomaly/light_lof.cpp
+++ b/jubatus/core/anomaly/light_lof.cpp
@@ -164,7 +164,7 @@ bool light_lof::set_row(const std::string& id, const common::sfv_t& sfv) {
   // Reject adding points that have the same fv for k times.
   // This helps avoiding LRD to become inf (so that LOF scores of its
   // neighbors won't go inf.)
-  if (*config_.ignore_kth_same_point) {
+  if (config_.ignore_kth_same_point && *config_.ignore_kth_same_point) {
     std::vector<std::pair<std::string, float> > nn_result;
 
     // Find k-1 NNs for the given sfv.

--- a/jubatus/core/anomaly/light_lof_test.cpp
+++ b/jubatus/core/anomaly/light_lof_test.cpp
@@ -198,6 +198,12 @@ TYPED_TEST_P(light_lof_test, config_validation) {
   c.reverse_nearest_neighbor_num = 3;
   ASSERT_NO_THROW
     (this->light_lof_.reset(new light_lof(c, ID, this->nn_engine_)));
+
+  // ignore_kth_same_point is undefined
+  c.ignore_kth_same_point = jubatus::util::data::optional<bool>();
+  ASSERT_NO_THROW(
+    this->light_lof_.reset(new light_lof(c, ID, this->nn_engine_)));
+  EXPECT_TRUE(this->light_lof_->set_row("test", common::sfv_t()));
 }
 
 REGISTER_TYPED_TEST_CASE_P(


### PR DESCRIPTION
Previously jubaanomaly run with config that does not define ``ignore_kth_same_point`` parameter cause SegV on calling ``set`` RPC.
This patch fixes the problem.