### PR TITLE
Fix bit_index_storage to ignore 0-bit vector in analyze methods

### DIFF
--- a/jubatus/core/storage/bit_index_storage_test.cpp
+++ b/jubatus/core/storage/bit_index_storage_test.cpp
@@ -113,6 +113,10 @@ TEST(bit_index_storage, row_operations) {
   s1.get_all_row_ids(ids);
   EXPECT_EQ(1u, ids.size());
 
+  std::vector<std::pair<std::string, float> > similar_result;
+  s1.similar_row(make_vector("0101"), similar_result, 10);
+  EXPECT_EQ(1u, similar_result.size());
+
   // do MIX
   bit_table_t d2;
   s1.get_diff(d2);


### PR DESCRIPTION
This PR fixes the issue reported in #211.
Prior to this fix, analyze methods of `bit_index_storage` (used by LSH / MinHash algorithms of recommender) did not work until next MIX if rows are erased by `clear_row`

I also improved several comments.