### PR TITLE
(develop) fix inverted_index_storage::calc_euclid_scores to ignore remove row

### DIFF
--- a/jubatus/core/storage/inverted_index_storage.cpp
+++ b/jubatus/core/storage/inverted_index_storage.cpp
@@ -388,6 +388,11 @@ void inverted_index_storage::calc_euclid_scores(
   for (size_t i = 0; i < i_scores.size(); ++i) {
     float norm = calc_columnl2norm(i);
 
+    if (norm == 0.f) {
+      // The column is already removed.
+      continue;
+    }
+
     // `d2` is a squared euclidean distance.
     // In edgy cases, `d2` may sliglty become negative (which is actually
     // expected to be 0) due to the floating point precision problem.

--- a/jubatus/core/storage/inverted_index_storage_test.cpp
+++ b/jubatus/core/storage/inverted_index_storage_test.cpp
@@ -106,12 +106,23 @@ TEST(inverted_index_storage, trivial_euclid) {
   vector<pair<string, float> > scores;
   s.calc_euclid_scores(v, scores, 100);
 
+  ASSERT_EQ(3, scores.size());
   EXPECT_EQ("r1", scores[0].first);
   EXPECT_FLOAT_EQ(-1, scores[0].second);
   EXPECT_EQ("r3", scores[1].first);
   EXPECT_FLOAT_EQ(- sqrt(2), scores[1].second);
   EXPECT_EQ("r2", scores[2].first);
   EXPECT_FLOAT_EQ(- sqrt(3), scores[2].second);
+
+  // remove column "r3"
+  s.remove("c2", "r3");
+  s.remove("c5", "r3");
+
+  scores.clear();
+  s.calc_euclid_scores(v, scores, 100);
+  ASSERT_EQ(2, scores.size());
+  EXPECT_EQ("r1", scores[0].first);
+  EXPECT_EQ("r2", scores[1].first);
 }
 
 TEST(inverted_index_storage, diff) {


### PR DESCRIPTION
This bug was introduced in #127.
Rows removed by `clear_row` was not ignored when calculating Euclidean distance in inverted_index.