### PR TITLE
optimized random_projection

### DIFF
--- a/jubatus/core/anomaly/light_lof_test.cpp
+++ b/jubatus/core/anomaly/light_lof_test.cpp
@@ -137,7 +137,7 @@ TYPED_TEST_P(light_lof_test, get_all_row_ids) {
 
 TYPED_TEST_P(light_lof_test, calc_anomaly_score_on_gaussian_random_samples) {
   const vector<common::sfv_t> random_points =
-      draw_2d_points_from_gaussian(100, 3, 1, 1, 0.5, this->mtr_);
+      draw_2d_points_from_gaussian(90, 3, 1, 1, 0.5, this->mtr_);
   for (size_t i = 0; i < random_points.size(); ++i) {
     this->light_lof_->set_row(lexical_cast<string>(i), random_points[i]);
   }

--- a/jubatus/core/nearest_neighbor/avx_mathfunc.hpp
+++ b/jubatus/core/nearest_neighbor/avx_mathfunc.hpp
@@ -1,0 +1,212 @@
+/*
+   AVX implementation of sin, cos, sincos, exp and log
+
+   Based on "sse_mathfun.h", by Julien Pommier
+   http://gruntthepeon.free.fr/ssemath/
+
+   Copyright (C) 2012 Giovanni Garberoglio
+   Interdisciplinary Laboratory for Computational Science (LISC)
+   Fondazione Bruno Kessler and University of Trento
+   via Sommarive, 18
+   I-38123 Trento (Italy)
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  (this is the zlib license)
+*/
+/*
+   log256_ps and sincos256_ps function is based from below URL.
+   http://software-lisc.fbk.eu/avx_mathfun/
+
+   Modifications:
+   * remove other math functions
+   * remove SSE fallback code
+   * function multiversioning friendly
+   * fixed compiler warning
+   * fixed that cpplint pointed out
+*/
+
+#ifndef JUBATUS_CORE_NEAREST_NEIGHBOR_AVX_MATHFUNC_HPP_
+#define JUBATUS_CORE_NEAREST_NEIGHBOR_AVX_MATHFUNC_HPP_
+#ifdef JUBATUS_USE_FMV
+
+#include <immintrin.h>
+#include "jubatus/util/math/constant.h"
+
+#define _PS256_CONST(Name, Val)                                         \
+  static const float _ps256_##Name##_f32[8] __attribute__((aligned(32))) = { \
+    Val, Val, Val, Val, Val, Val, Val, Val};                            \
+  static const __m256 *_ps256_##Name =                                  \
+    reinterpret_cast<const __m256*>(_ps256_##Name##_f32)
+#define _PI256_CONST(Name, Val)                                         \
+  static const int _pi256_##Name##_i32[8] __attribute__((aligned(32))) = { \
+    Val, Val, Val, Val, Val, Val, Val, Val};                            \
+  static const __m256i *_pi256_##Name =                                 \
+    reinterpret_cast<const __m256i*>(_pi256_##Name##_i32)
+
+_PI256_CONST(min_norm_pos, static_cast<int>(0x00800000));
+_PI256_CONST(inv_mant_mask, static_cast<int>(~0x7f800000));
+_PS256_CONST(cephes_log_p0, 7.0376836292E-2);
+_PS256_CONST(cephes_log_p1, - 1.1514610310E-1);
+_PS256_CONST(cephes_log_p2, 1.1676998740E-1);
+_PS256_CONST(cephes_log_p3, - 1.2420140846E-1);
+_PS256_CONST(cephes_log_p4, + 1.4249322787E-1);
+_PS256_CONST(cephes_log_p5, - 1.6668057665E-1);
+_PS256_CONST(cephes_log_p6, + 2.0000714765E-1);
+_PS256_CONST(cephes_log_p7, - 2.4999993993E-1);
+_PS256_CONST(cephes_log_p8, + 3.3333331174E-1);
+_PS256_CONST(cephes_log_q1, -2.12194440e-4);
+_PS256_CONST(cephes_log_q2, 0.693359375);
+_PS256_CONST(cephes_SQRTHF, 0.707106781186547524);
+_PI256_CONST(0x7f, 0x7f);
+_PI256_CONST(sign_mask, static_cast<int>(0x80000000));
+_PI256_CONST(inv_sign_mask, static_cast<int>(~0x80000000));
+_PS256_CONST(cephes_FOPI, 1.27323954473516);  // 4 / M_PI
+_PS256_CONST(minus_cephes_DP1, -0.78515625);
+_PS256_CONST(minus_cephes_DP2, -2.4187564849853515625e-4);
+_PS256_CONST(minus_cephes_DP3, -3.77489497744594108e-8);
+_PS256_CONST(sincof_p0, -1.9515295891E-4);
+_PS256_CONST(sincof_p1,  8.3321608736E-3);
+_PS256_CONST(sincof_p2, -1.6666654611E-1);
+_PS256_CONST(coscof_p0,  2.443315711809948E-005);
+_PS256_CONST(coscof_p1, -1.388731625493765E-003);
+_PS256_CONST(coscof_p2,  4.166664568298827E-002);
+_PS256_CONST(1  , 1.0f);
+_PS256_CONST(0p5, 0.5f);
+_PI256_CONST(0, 0);
+_PI256_CONST(1, 1);
+_PI256_CONST(inv1, ~1);
+_PI256_CONST(2, 2);
+_PI256_CONST(4, 4);
+_PS256_CONST(minus2, -2.0f);
+_PS256_CONST(scale , static_cast<float>(1.0 / 16777216.0));
+_PS256_CONST(twopi , static_cast<float>(2.0 * jubatus::util::math::pi));
+
+__attribute__((target("avx2")))
+static inline __m256 log256_ps(__m256 x) {
+  __m256i imm0;
+  __m256 one = *_ps256_1;
+  __m256 invalid_mask = _mm256_cmp_ps(x, _mm256_setzero_ps(), _CMP_LE_OS);
+  x = _mm256_max_ps(x, *reinterpret_cast<const __m256*>(_pi256_min_norm_pos));
+  imm0 = _mm256_srli_epi32(_mm256_castps_si256(x), 23);
+  x = _mm256_and_ps(x, *reinterpret_cast<const __m256*>(_pi256_inv_mant_mask));
+  x = _mm256_or_ps(x, *_ps256_0p5);
+  imm0 = _mm256_sub_epi32(imm0, *_pi256_0x7f);
+  __m256 e = _mm256_cvtepi32_ps(imm0);
+  e = _mm256_add_ps(e, one);
+  __m256 mask = _mm256_cmp_ps(x, *_ps256_cephes_SQRTHF, _CMP_LT_OS);
+  __m256 tmp = _mm256_and_ps(x, mask);
+  x = _mm256_sub_ps(x, one);
+  e = _mm256_sub_ps(e, _mm256_and_ps(one, mask));
+  x = _mm256_add_ps(x, tmp);
+  __m256 z = _mm256_mul_ps(x, x);
+  __m256 y = *_ps256_cephes_log_p0;
+  y = _mm256_mul_ps(y, x);
+  y = _mm256_add_ps(y, *_ps256_cephes_log_p1);
+  y = _mm256_mul_ps(y, x);
+  y = _mm256_add_ps(y, *_ps256_cephes_log_p2);
+  y = _mm256_mul_ps(y, x);
+  y = _mm256_add_ps(y, *_ps256_cephes_log_p3);
+  y = _mm256_mul_ps(y, x);
+  y = _mm256_add_ps(y, *_ps256_cephes_log_p4);
+  y = _mm256_mul_ps(y, x);
+  y = _mm256_add_ps(y, *_ps256_cephes_log_p5);
+  y = _mm256_mul_ps(y, x);
+  y = _mm256_add_ps(y, *_ps256_cephes_log_p6);
+  y = _mm256_mul_ps(y, x);
+  y = _mm256_add_ps(y, *_ps256_cephes_log_p7);
+  y = _mm256_mul_ps(y, x);
+  y = _mm256_add_ps(y, *_ps256_cephes_log_p8);
+  y = _mm256_mul_ps(y, x);
+  y = _mm256_mul_ps(y, z);
+  tmp = _mm256_mul_ps(e, *_ps256_cephes_log_q1);
+  y = _mm256_add_ps(y, tmp);
+  tmp = _mm256_mul_ps(z, *_ps256_0p5);
+  y = _mm256_sub_ps(y, tmp);
+  tmp = _mm256_mul_ps(e, *_ps256_cephes_log_q2);
+  x = _mm256_add_ps(x, y);
+  x = _mm256_add_ps(x, tmp);
+  x = _mm256_or_ps(x, invalid_mask);
+  return x;
+}
+
+__attribute__((target("avx2")))
+static inline void sincos256_ps(__m256 x, __m256 *s, __m256 *c) {
+  __m256 xmm1, xmm2, xmm3 = _mm256_setzero_ps(), sign_bit_sin, y;
+  __m256i imm0, imm2, imm4;
+  sign_bit_sin = x;
+  x = _mm256_and_ps(x, *reinterpret_cast<const __m256*>(_pi256_inv_sign_mask));
+  sign_bit_sin = _mm256_and_ps(
+    sign_bit_sin, *reinterpret_cast<const __m256*>(_pi256_sign_mask));
+  y = _mm256_mul_ps(x, *_ps256_cephes_FOPI);
+  imm2 = _mm256_cvttps_epi32(y);
+  imm2 = _mm256_add_epi32(imm2, *_pi256_1);
+  imm2 = _mm256_and_si256(imm2, *_pi256_inv1);
+  y = _mm256_cvtepi32_ps(imm2);
+  imm4 = imm2;
+  imm0 = _mm256_and_si256(imm2, *_pi256_4);
+  imm0 = _mm256_slli_epi32(imm0, 29);
+  imm2 = _mm256_and_si256(imm2, *_pi256_2);
+  imm2 = _mm256_cmpeq_epi32(imm2, *_pi256_0);
+  __m256 swap_sign_bit_sin = _mm256_castsi256_ps(imm0);
+  __m256 poly_mask = _mm256_castsi256_ps(imm2);
+  xmm1 = *_ps256_minus_cephes_DP1;
+  xmm2 = *_ps256_minus_cephes_DP2;
+  xmm3 = *_ps256_minus_cephes_DP3;
+  xmm1 = _mm256_mul_ps(y, xmm1);
+  xmm2 = _mm256_mul_ps(y, xmm2);
+  xmm3 = _mm256_mul_ps(y, xmm3);
+  x = _mm256_add_ps(x, xmm1);
+  x = _mm256_add_ps(x, xmm2);
+  x = _mm256_add_ps(x, xmm3);
+  imm4 = _mm256_sub_epi32(imm4, *_pi256_2);
+  imm4 = _mm256_andnot_si256(imm4, *_pi256_4);
+  imm4 = _mm256_slli_epi32(imm4, 29);
+  __m256 sign_bit_cos = _mm256_castsi256_ps(imm4);
+  sign_bit_sin = _mm256_xor_ps(sign_bit_sin, swap_sign_bit_sin);
+  __m256 z = _mm256_mul_ps(x, x);
+  y = *_ps256_coscof_p0;
+  y = _mm256_mul_ps(y, z);
+  y = _mm256_add_ps(y, *_ps256_coscof_p1);
+  y = _mm256_mul_ps(y, z);
+  y = _mm256_add_ps(y, *_ps256_coscof_p2);
+  y = _mm256_mul_ps(y, z);
+  y = _mm256_mul_ps(y, z);
+  __m256 tmp = _mm256_mul_ps(z, *_ps256_0p5);
+  y = _mm256_sub_ps(y, tmp);
+  y = _mm256_add_ps(y, *_ps256_1);
+  __m256 y2 = *_ps256_sincof_p0;
+  y2 = _mm256_mul_ps(y2, z);
+  y2 = _mm256_add_ps(y2, *_ps256_sincof_p1);
+  y2 = _mm256_mul_ps(y2, z);
+  y2 = _mm256_add_ps(y2, *_ps256_sincof_p2);
+  y2 = _mm256_mul_ps(y2, z);
+  y2 = _mm256_mul_ps(y2, x);
+  y2 = _mm256_add_ps(y2, x);
+  xmm3 = poly_mask;
+  __m256 ysin2 = _mm256_and_ps(xmm3, y2);
+  __m256 ysin1 = _mm256_andnot_ps(xmm3, y);
+  y2 = _mm256_sub_ps(y2, ysin2);
+  y = _mm256_sub_ps(y, ysin1);
+  xmm1 = _mm256_add_ps(ysin1, ysin2);
+  xmm2 = _mm256_add_ps(y, y2);
+  *s = _mm256_xor_ps(xmm1, sign_bit_sin);
+  *c = _mm256_xor_ps(xmm2, sign_bit_cos);
+}
+
+#endif  // #ifdef  JUBATUS_USE_FMV
+#endif  // #ifndef JUBATUS_CORE_NEAREST_NEIGHBOR_AVX_MATHFUNC_HPP_

--- a/jubatus/core/nearest_neighbor/lsh_function.cpp
+++ b/jubatus/core/nearest_neighbor/lsh_function.cpp
@@ -85,7 +85,7 @@ vector<float> random_projection_internal(const common::sfv_t& sfv,
   vector<float> proj(hash_num);
   for (size_t i = 0; i < sfv.size(); ++i) {
     const uint32_t seed = common::hash_util::calc_string_hash(sfv[i].first);
-    jubatus::util::math::random::mtrand rnd(seed);
+    jubatus::util::math::random::sfmt607rand rnd(seed);
     for (uint32_t j = 0; j < hash_num; ++j) {
       proj[j] += sfv[i].second * rnd.next_gaussian_float();
     }
@@ -106,7 +106,7 @@ vector<float> random_projection_internal(const common::sfv_t& sfv,
   float grnd[8] __attribute__((aligned(16)));
   for (size_t i = 0; i < sfv.size(); ++i) {
     const uint32_t seed = common::hash_util::calc_string_hash(sfv[i].first);
-    jubatus::util::math::random::mtrand rnd(seed);
+    jubatus::util::math::random::sfmt607rand rnd(seed);
     const float v = sfv[i].second;
     __m128 v4 = _mm_set1_ps(v);
     uint32_t j = 0;
@@ -134,9 +134,7 @@ inline void next_gaussian_float8(RND& g, float *out) {
   __m128 a, b;
   {
     __m128i t[2] __attribute__((aligned(16)));
-    uint32_t *p = reinterpret_cast<uint32_t*>(&(t[0]));
-    for (int i = 0; i < 8; ++i)
-      p[i] = g.next_int();
+    g.fill_int_unsafe(reinterpret_cast<uint32_t*>(&(t[0])), 8);
     a = _mm_cvtepi32_ps(_mm_srli_epi32(t[0], 8));
     b = _mm_cvtepi32_ps(_mm_srli_epi32(t[1], 8));
     __m128 c = _mm_unpacklo_ps(a, b);
@@ -172,7 +170,7 @@ vector<float> random_projection_internal(const common::sfv_t& sfv,
   float grnd[16] __attribute__((aligned(32)));
   for (size_t i = 0; i < sfv.size(); ++i) {
     const uint32_t seed = common::hash_util::calc_string_hash(sfv[i].first);
-    jubatus::util::math::random::mtrand rnd(seed);
+    jubatus::util::math::random::sfmt607rand rnd(seed);
     const float v = sfv[i].second;
     __m256 v8 = _mm256_set1_ps(v);
     uint32_t j = 0;
@@ -209,9 +207,7 @@ inline static void next_gaussian_float16(RND& g, float *out) {
   __m256 a, b;
   {
     __m256i t[2] __attribute__((aligned(32)));
-    uint32_t *p = reinterpret_cast<uint32_t*>(&(t[0]));
-    for (int i = 0; i < 16; ++i)
-      p[i] = g.next_int();
+    g.fill_int_unsafe(reinterpret_cast<uint32_t*>(&(t[0])), 16);
     a = _mm256_cvtepi32_ps(_mm256_srli_epi32(t[0], 8));
     b = _mm256_cvtepi32_ps(_mm256_srli_epi32(t[1], 8));
     __m256 c = _mm256_unpacklo_ps(a, b);

--- a/jubatus/core/nearest_neighbor/lsh_function.cpp
+++ b/jubatus/core/nearest_neighbor/lsh_function.cpp
@@ -34,7 +34,7 @@ vector<float> random_projection(const common::sfv_t& sfv, uint32_t hash_num) {
     const uint32_t seed = common::hash_util::calc_string_hash(sfv[i].first);
     jubatus::util::math::random::mtrand rnd(seed);
     for (uint32_t j = 0; j < hash_num; ++j) {
-      proj[j] += sfv[i].second * rnd.next_gaussian();
+      proj[j] += sfv[i].second * rnd.next_gaussian_float();
     }
   }
   return proj;

--- a/jubatus/core/nearest_neighbor/lsh_function.cpp
+++ b/jubatus/core/nearest_neighbor/lsh_function.cpp
@@ -14,12 +14,13 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-#include <vector>
-#include "jubatus/util/math/random.h"
-#include "../common/hash.hpp"
-#include "../common/type.hpp"
-#include "../storage/bit_vector.hpp"
 #include "lsh_function.hpp"
+
+#include <vector>
+#include "../common/hash.hpp"
+#include "jubatus/util/math/random.h"
+#include "sse_mathfunc.hpp"
+#include "avx_mathfunc.hpp"
 
 using std::vector;
 using jubatus::core::storage::bit_vector;
@@ -27,17 +28,36 @@ using jubatus::core::storage::bit_vector;
 namespace jubatus {
 namespace core {
 namespace nearest_neighbor {
+namespace {
+
+std::vector<float> random_projection_internal(
+  const common::sfv_t& sfv, uint32_t hash_num);
+
+#if defined(__SSE2__) || defined(JUBATUS_USE_FMV)
+template <class RND>
+inline void next_gaussian_float8(RND& g, float *out);
+#endif
+
+#ifdef JUBATUS_USE_FMV
+__attribute__((target("default")))
+std::vector<float> random_projection_internal(
+  const common::sfv_t& sfv, uint32_t hash_num);
+
+__attribute__((target("sse2")))
+std::vector<float> random_projection_internal(
+  const common::sfv_t& sfv, uint32_t hash_num);
+
+__attribute__((target("avx2")))
+std::vector<float> random_projection_internal(
+  const common::sfv_t& sfv, uint32_t hash_num);
+
+template <class RND> __attribute__((target("avx2")))
+inline void next_gaussian_float16(RND& g, float *out);
+#endif
+}
 
 vector<float> random_projection(const common::sfv_t& sfv, uint32_t hash_num) {
-  vector<float> proj(hash_num);
-  for (size_t i = 0; i < sfv.size(); ++i) {
-    const uint32_t seed = common::hash_util::calc_string_hash(sfv[i].first);
-    jubatus::util::math::random::mtrand rnd(seed);
-    for (uint32_t j = 0; j < hash_num; ++j) {
-      proj[j] += sfv[i].second * rnd.next_gaussian_float();
-    }
-  }
-  return proj;
+  return random_projection_internal(sfv, hash_num);
 }
 
 bit_vector binarize(const vector<float>& proj) {
@@ -54,6 +74,170 @@ bit_vector cosine_lsh(const common::sfv_t& sfv, uint32_t hash_num) {
   return binarize(random_projection(sfv, hash_num));
 }
 
+namespace {
+
+#if !defined(__SSE2__) || defined(JUBATUS_USE_FMV)
+#ifdef JUBATUS_USE_FMV
+__attribute__((target("default")))
+#endif
+vector<float> random_projection_internal(const common::sfv_t& sfv,
+                                         uint32_t hash_num) {
+  vector<float> proj(hash_num);
+  for (size_t i = 0; i < sfv.size(); ++i) {
+    const uint32_t seed = common::hash_util::calc_string_hash(sfv[i].first);
+    jubatus::util::math::random::mtrand rnd(seed);
+    for (uint32_t j = 0; j < hash_num; ++j) {
+      proj[j] += sfv[i].second * rnd.next_gaussian_float();
+    }
+  }
+  return proj;
+}
+#endif  // #if !defined(__SSE2__) || defined(JUBATUS_ENABLED_FUNCTION_MULTIV...
+
+#if defined(__SSE2__) || defined(JUBATUS_USE_FMV)
+#ifdef JUBATUS_USE_FMV
+__attribute__((target("sse2")))
+#endif
+vector<float> random_projection_internal(const common::sfv_t& sfv,
+                                         uint32_t hash_num) {
+  std::vector<float> proj(hash_num);
+  float *p = const_cast<float*>(proj.data());
+  uint32_t hash_num_sse = hash_num & 0xfffffff8;
+  float grnd[8] __attribute__((aligned(16)));
+  for (size_t i = 0; i < sfv.size(); ++i) {
+    const uint32_t seed = common::hash_util::calc_string_hash(sfv[i].first);
+    jubatus::util::math::random::mtrand rnd(seed);
+    const float v = sfv[i].second;
+    __m128 v4 = _mm_set1_ps(v);
+    uint32_t j = 0;
+    for (; j < hash_num_sse; j += 8) {
+      next_gaussian_float8(rnd, grnd);
+      __m128 t0 = _mm_loadu_ps(p + j);
+      __m128 t1 = _mm_loadu_ps(p + j + 4);
+      __m128 t2 = _mm_mul_ps(v4, _mm_load_ps(grnd));
+      __m128 t3 = _mm_mul_ps(v4, _mm_load_ps(grnd + 4));
+      _mm_storeu_ps(p + j + 0, _mm_add_ps(t0, t2));
+      _mm_storeu_ps(p + j + 4, _mm_add_ps(t1, t3));
+    }
+    for (; j < hash_num; ++j) {
+      proj[j] += v * rnd.next_gaussian_float();
+    }
+  }
+  return proj;
+}
+
+template <class RND>
+#ifdef JUBATUS_USE_FMV
+__attribute__((target("sse2")))
+#endif
+inline void next_gaussian_float8(RND& g, float *out) {
+  __m128 a, b;
+  {
+    __m128i t[2] __attribute__((aligned(16)));
+    uint32_t *p = reinterpret_cast<uint32_t*>(&(t[0]));
+    for (int i = 0; i < 8; ++i)
+      p[i] = g.next_int();
+    a = _mm_cvtepi32_ps(_mm_srli_epi32(t[0], 8));
+    b = _mm_cvtepi32_ps(_mm_srli_epi32(t[1], 8));
+    __m128 c = _mm_unpacklo_ps(a, b);
+    __m128 d = _mm_unpackhi_ps(a, b);
+    a = _mm_unpacklo_ps(c, d);
+    b = _mm_unpackhi_ps(c, d);
+  }
+  a = _mm_mul_ps(a, *_ps_scale);
+  b = _mm_mul_ps(b, *_ps_scale);
+  a = _mm_sub_ps(*_ps_1, a);
+  b = _mm_sub_ps(*_ps_1, b);
+  b = _mm_mul_ps(b, *_ps_twopi);
+  a = log_ps(a);
+  __m128 s, c;
+  sincos_ps(b, &s, &c);
+  a = _mm_mul_ps(a, *_ps_minus2);
+  a = _mm_sqrt_ps(a);
+  b = _mm_mul_ps(a, s);
+  a = _mm_mul_ps(a, c);
+  _mm_storeu_ps(out + 0, _mm_unpacklo_ps(b, a));
+  _mm_storeu_ps(out + 4, _mm_unpackhi_ps(b, a));
+}
+
+#endif  // #if defined(__SSE2__) || defined(JUBATUS_ENABLED_FUNCTION_MULTIVE...
+
+#ifdef JUBATUS_USE_FMV
+__attribute__((target("avx2")))
+vector<float> random_projection_internal(const common::sfv_t& sfv,
+                                         uint32_t hash_num) {
+  std::vector<float> proj(hash_num);
+  float *p = const_cast<float*>(proj.data());
+  uint32_t hash_num_avx = hash_num & 0xfffffff0;
+  float grnd[16] __attribute__((aligned(32)));
+  for (size_t i = 0; i < sfv.size(); ++i) {
+    const uint32_t seed = common::hash_util::calc_string_hash(sfv[i].first);
+    jubatus::util::math::random::mtrand rnd(seed);
+    const float v = sfv[i].second;
+    __m256 v8 = _mm256_set1_ps(v);
+    uint32_t j = 0;
+    for (; j < hash_num_avx; j += 16) {
+      next_gaussian_float16(rnd, grnd);
+      __m256 t0 = _mm256_loadu_ps(p + j);
+      __m256 t1 = _mm256_loadu_ps(p + j + 8);
+      __m256 t2 = _mm256_mul_ps(v8, _mm256_load_ps(grnd));
+      __m256 t3 = _mm256_mul_ps(v8, _mm256_load_ps(grnd + 8));
+      _mm256_storeu_ps(p + j + 0, _mm256_add_ps(t0, t2));
+      _mm256_storeu_ps(p + j + 8, _mm256_add_ps(t1, t3));
+    }
+    if (j < hash_num) {
+      __m128 v4 = _mm_set1_ps(v);
+      for (; j < hash_num - 7; j += 8) {
+        next_gaussian_float8(rnd, grnd);
+        __m128 t0 = _mm_loadu_ps(p + j);
+        __m128 t1 = _mm_loadu_ps(p + j + 4);
+        __m128 t2 = _mm_mul_ps(v4, _mm_load_ps(grnd));
+        __m128 t3 = _mm_mul_ps(v4, _mm_load_ps(grnd + 4));
+        _mm_storeu_ps(p + j + 0, _mm_add_ps(t0, t2));
+        _mm_storeu_ps(p + j + 4, _mm_add_ps(t1, t3));
+      }
+      for (; j < hash_num; ++j) {
+        proj[j] += v * rnd.next_gaussian_float();
+      }
+    }
+  }
+  return proj;
+}
+
+template <class RND> __attribute__((target("avx2")))
+inline static void next_gaussian_float16(RND& g, float *out) {
+  __m256 a, b;
+  {
+    __m256i t[2] __attribute__((aligned(32)));
+    uint32_t *p = reinterpret_cast<uint32_t*>(&(t[0]));
+    for (int i = 0; i < 16; ++i)
+      p[i] = g.next_int();
+    a = _mm256_cvtepi32_ps(_mm256_srli_epi32(t[0], 8));
+    b = _mm256_cvtepi32_ps(_mm256_srli_epi32(t[1], 8));
+    __m256 c = _mm256_unpacklo_ps(a, b);
+    __m256 d = _mm256_unpackhi_ps(a, b);
+    a = _mm256_unpacklo_ps(c, d);
+    b = _mm256_unpackhi_ps(c, d);
+  }
+  a = _mm256_mul_ps(a, *_ps256_scale);
+  b = _mm256_mul_ps(b, *_ps256_scale);
+  a = _mm256_sub_ps(*_ps256_1, a);
+  b = _mm256_sub_ps(*_ps256_1, b);
+  b = _mm256_mul_ps(b, *_ps256_twopi);
+  a = log256_ps(a);
+  __m256 s, c;
+  sincos256_ps(b, &s, &c);
+  a = _mm256_mul_ps(a, *_ps256_minus2);
+  a = _mm256_sqrt_ps(a);
+  b = _mm256_mul_ps(a, s);
+  a = _mm256_mul_ps(a, c);
+  _mm256_store_ps(out + 0, _mm256_unpacklo_ps(b, a));
+  _mm256_store_ps(out + 8, _mm256_unpackhi_ps(b, a));
+}
+
+#endif  // #ifdef JUBATUS_USE_FMV
+
+}  // namespace
 }  // namespace nearest_neighbor
 }  // namespace core
 }  // namespace jubatus

--- a/jubatus/core/nearest_neighbor/sse_mathfunc.hpp
+++ b/jubatus/core/nearest_neighbor/sse_mathfunc.hpp
@@ -1,0 +1,217 @@
+/* SIMD (SSE1+MMX or SSE2) implementation of sin, cos, exp and log
+
+   Inspired by Intel Approximate Math library, and based on the
+   corresponding algorithms of the cephes math library
+
+   The default is to use the SSE1 version. If you define USE_SSE2 the
+   the SSE2 intrinsics will be used in place of the MMX intrinsics. Do
+   not expect any significant performance improvement with SSE2.
+*/
+/* Copyright (C) 2007  Julien Pommier
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  (this is the zlib license)
+*/
+/*
+   log_ps and sincos_ps function is based from below URL.
+   http://gruntthepeon.free.fr/ssemath/
+
+   Modifications:
+   * remove SSE1+MMX code
+   * remove other math functions
+   * function multiversioning friendly
+   * fixed that cpplint pointed out
+*/
+
+#ifndef JUBATUS_CORE_NEAREST_NEIGHBOR_SSE_MATHFUNC_HPP_
+#define JUBATUS_CORE_NEAREST_NEIGHBOR_SSE_MATHFUNC_HPP_
+#if defined(__SSE2__) || defined(JUBATUS_USE_FMV)
+
+#if defined(JUBATUS_USE_FMV)
+#include <immintrin.h>
+#elif defined(__SSE2__)
+#include <emmintrin.h>
+#endif
+#include "jubatus/util/math/constant.h"
+
+#define _PS_CONST(Name, Val)                                            \
+  static const float _ps_##Name##_f32[4] __attribute__((aligned(16))) = { \
+    Val, Val, Val, Val};                                                \
+  static const __m128 *_ps_##Name =                                     \
+    reinterpret_cast<const __m128*>(_ps_##Name##_f32)
+#define _PI_CONST(Name, Val)                                            \
+  static const int _pi_##Name##_i32[4] __attribute__((aligned(16))) = { \
+    Val, Val, Val, Val};                                                \
+  static const __m128i *_pi_##Name =                                    \
+    reinterpret_cast<const __m128i*>(_pi_##Name##_i32)
+
+_PS_CONST(1  , 1.0f);
+_PS_CONST(0p5, 0.5f);
+_PI_CONST(min_norm_pos, 0x00800000);
+_PI_CONST(inv_mant_mask, ~0x7f800000);
+_PI_CONST(sign_mask, static_cast<int>(0x80000000));
+_PI_CONST(inv_sign_mask, ~0x80000000);
+_PI_CONST(1, 1);
+_PI_CONST(inv1, ~1);
+_PI_CONST(2, 2);
+_PI_CONST(4, 4);
+_PI_CONST(0x7f, 0x7f);
+_PS_CONST(cephes_SQRTHF, 0.707106781186547524);
+_PS_CONST(cephes_log_p0, 7.0376836292E-2);
+_PS_CONST(cephes_log_p1, - 1.1514610310E-1);
+_PS_CONST(cephes_log_p2, 1.1676998740E-1);
+_PS_CONST(cephes_log_p3, - 1.2420140846E-1);
+_PS_CONST(cephes_log_p4, + 1.4249322787E-1);
+_PS_CONST(cephes_log_p5, - 1.6668057665E-1);
+_PS_CONST(cephes_log_p6, + 2.0000714765E-1);
+_PS_CONST(cephes_log_p7, - 2.4999993993E-1);
+_PS_CONST(cephes_log_p8, + 3.3333331174E-1);
+_PS_CONST(cephes_log_q1, -2.12194440e-4);
+_PS_CONST(cephes_log_q2, 0.693359375);
+_PS_CONST(minus_cephes_DP1, -0.78515625);
+_PS_CONST(minus_cephes_DP2, -2.4187564849853515625e-4);
+_PS_CONST(minus_cephes_DP3, -3.77489497744594108e-8);
+_PS_CONST(sincof_p0, -1.9515295891E-4);
+_PS_CONST(sincof_p1,  8.3321608736E-3);
+_PS_CONST(sincof_p2, -1.6666654611E-1);
+_PS_CONST(coscof_p0,  2.443315711809948E-005);
+_PS_CONST(coscof_p1, -1.388731625493765E-003);
+_PS_CONST(coscof_p2,  4.166664568298827E-002);
+_PS_CONST(cephes_FOPI, 1.27323954473516);  // 4 / M_PI
+_PS_CONST(minus2, -2.0f);
+_PS_CONST(scale, static_cast<float>(1.0 / 16777216.0));
+_PS_CONST(twopi, static_cast<float>(2.0 * jubatus::util::math::pi));
+
+#ifdef JUBATUS_USE_FMV
+__attribute__((target("sse2")))
+#endif
+__m128 log_ps(__m128 x) {
+  __m128i emm0;
+  __m128 one = *_ps_1;
+  __m128 invalid_mask = _mm_cmple_ps(x, _mm_setzero_ps());
+  x = _mm_max_ps(x, *reinterpret_cast<const __m128*>(_pi_min_norm_pos));
+  emm0 = _mm_srli_epi32(_mm_castps_si128(x), 23);
+  x = _mm_and_ps(x, *reinterpret_cast<const __m128*>(_pi_inv_mant_mask));
+  x = _mm_or_ps(x, *_ps_0p5);
+  emm0 = _mm_sub_epi32(emm0, *_pi_0x7f);
+  __m128 e = _mm_cvtepi32_ps(emm0);
+  e = _mm_add_ps(e, one);
+  __m128 mask = _mm_cmplt_ps(x, *_ps_cephes_SQRTHF);
+  __m128 tmp = _mm_and_ps(x, mask);
+  x = _mm_sub_ps(x, one);
+  e = _mm_sub_ps(e, _mm_and_ps(one, mask));
+  x = _mm_add_ps(x, tmp);
+  __m128 z = _mm_mul_ps(x, x);
+  __m128 y = *_ps_cephes_log_p0;
+  y = _mm_mul_ps(y, x);
+  y = _mm_add_ps(y, *_ps_cephes_log_p1);
+  y = _mm_mul_ps(y, x);
+  y = _mm_add_ps(y, *_ps_cephes_log_p2);
+  y = _mm_mul_ps(y, x);
+  y = _mm_add_ps(y, *_ps_cephes_log_p3);
+  y = _mm_mul_ps(y, x);
+  y = _mm_add_ps(y, *_ps_cephes_log_p4);
+  y = _mm_mul_ps(y, x);
+  y = _mm_add_ps(y, *_ps_cephes_log_p5);
+  y = _mm_mul_ps(y, x);
+  y = _mm_add_ps(y, *_ps_cephes_log_p6);
+  y = _mm_mul_ps(y, x);
+  y = _mm_add_ps(y, *_ps_cephes_log_p7);
+  y = _mm_mul_ps(y, x);
+  y = _mm_add_ps(y, *_ps_cephes_log_p8);
+  y = _mm_mul_ps(y, x);
+  y = _mm_mul_ps(y, z);
+  tmp = _mm_mul_ps(e, *_ps_cephes_log_q1);
+  y = _mm_add_ps(y, tmp);
+  tmp = _mm_mul_ps(z, *_ps_0p5);
+  y = _mm_sub_ps(y, tmp);
+  tmp = _mm_mul_ps(e, *_ps_cephes_log_q2);
+  x = _mm_add_ps(x, y);
+  x = _mm_add_ps(x, tmp);
+  x = _mm_or_ps(x, invalid_mask);  // negative arg will be NAN
+  return x;
+}
+
+#ifdef JUBATUS_USE_FMV
+__attribute__((target("sse2")))
+#endif
+void sincos_ps(__m128 x, __m128 *s, __m128 *c) {
+  __m128 xmm1, xmm2, xmm3 = _mm_setzero_ps(), sign_bit_sin, y;
+  __m128i emm0, emm2, emm4;
+  sign_bit_sin = x;
+  x = _mm_and_ps(x, *reinterpret_cast<const __m128*>(_pi_inv_sign_mask));
+  sign_bit_sin = _mm_and_ps(sign_bit_sin,
+                            *reinterpret_cast<const __m128*>(_pi_sign_mask));
+  y = _mm_mul_ps(x, *_ps_cephes_FOPI);
+  emm2 = _mm_cvttps_epi32(y);
+  emm2 = _mm_add_epi32(emm2, *_pi_1);
+  emm2 = _mm_and_si128(emm2, *_pi_inv1);
+  y = _mm_cvtepi32_ps(emm2);
+  emm4 = emm2;
+  emm0 = _mm_and_si128(emm2, *_pi_4);
+  emm0 = _mm_slli_epi32(emm0, 29);
+  __m128 swap_sign_bit_sin = _mm_castsi128_ps(emm0);
+  emm2 = _mm_and_si128(emm2, *_pi_2);
+  emm2 = _mm_cmpeq_epi32(emm2, _mm_setzero_si128());
+  __m128 poly_mask = _mm_castsi128_ps(emm2);
+  xmm1 = *_ps_minus_cephes_DP1;
+  xmm2 = *_ps_minus_cephes_DP2;
+  xmm3 = *_ps_minus_cephes_DP3;
+  xmm1 = _mm_mul_ps(y, xmm1);
+  xmm2 = _mm_mul_ps(y, xmm2);
+  xmm3 = _mm_mul_ps(y, xmm3);
+  x = _mm_add_ps(x, xmm1);
+  x = _mm_add_ps(x, xmm2);
+  x = _mm_add_ps(x, xmm3);
+  emm4 = _mm_sub_epi32(emm4, *_pi_2);
+  emm4 = _mm_andnot_si128(emm4, *_pi_4);
+  emm4 = _mm_slli_epi32(emm4, 29);
+  __m128 sign_bit_cos = _mm_castsi128_ps(emm4);
+  sign_bit_sin = _mm_xor_ps(sign_bit_sin, swap_sign_bit_sin);
+  __m128 z = _mm_mul_ps(x, x);
+  y = *_ps_coscof_p0;
+  y = _mm_mul_ps(y, z);
+  y = _mm_add_ps(y, *_ps_coscof_p1);
+  y = _mm_mul_ps(y, z);
+  y = _mm_add_ps(y, *_ps_coscof_p2);
+  y = _mm_mul_ps(y, z);
+  y = _mm_mul_ps(y, z);
+  __m128 tmp = _mm_mul_ps(z, *_ps_0p5);
+  y = _mm_sub_ps(y, tmp);
+  y = _mm_add_ps(y, *_ps_1);
+  __m128 y2 = *_ps_sincof_p0;
+  y2 = _mm_mul_ps(y2, z);
+  y2 = _mm_add_ps(y2, *_ps_sincof_p1);
+  y2 = _mm_mul_ps(y2, z);
+  y2 = _mm_add_ps(y2, *_ps_sincof_p2);
+  y2 = _mm_mul_ps(y2, z);
+  y2 = _mm_mul_ps(y2, x);
+  y2 = _mm_add_ps(y2, x);
+  xmm3 = poly_mask;
+  __m128 ysin2 = _mm_and_ps(xmm3, y2);
+  __m128 ysin1 = _mm_andnot_ps(xmm3, y);
+  y2 = _mm_sub_ps(y2, ysin2);
+  y = _mm_sub_ps(y, ysin1);
+  xmm1 = _mm_add_ps(ysin1, ysin2);
+  xmm2 = _mm_add_ps(y, y2);
+  *s = _mm_xor_ps(xmm1, sign_bit_sin);
+  *c = _mm_xor_ps(xmm2, sign_bit_cos);
+}
+
+#endif  // #if defined(__SSE2__) || defined(JUBATUS_USE_FMV)
+#endif  // #ifndef JUBATUS_CORE_NEAREST_NEIGHBOR_SSE_MATHFUNC_HPP_

--- a/jubatus/util/math/random.h
+++ b/jubatus/util/math/random.h
@@ -39,6 +39,7 @@
 #include "../system/time_util.h"
 #include "constant.h"
 #include "random/mersenne_twister.h"
+#include "random/sfmt.h"
 
 namespace jubatus {
 namespace util{
@@ -68,6 +69,10 @@ public:
   /// generate [0,0xffffffff] random number
   uint32_t next_int(){
     return g.next();
+  }
+
+  void fill_int_unsafe(uint32_t *out, size_t count) {
+    g.fill_int_unsafe(out, count);
   }
   
   /// generate [0,\a a) random integer
@@ -162,6 +167,8 @@ private:
 };
 
 typedef random<mersenne_twister> mtrand;
+typedef random<sfmt607> sfmt607rand;
+typedef random<sfmt19937> sfmt19937rand;
 
 /// select k random integer from range [0,n), allowing multiple occurrence. O(k)
 template<typename RAND>

--- a/jubatus/util/math/random.h
+++ b/jubatus/util/math/random.h
@@ -80,6 +80,11 @@ public:
     return a+next_int(b-a);
   }
 
+  /// generates [0,1) random real number with 24bit resolution
+  float next_float(){
+    return (g.next() >> 8) * (1.0f / 16777216.0f);
+  }
+
   /// generates [0,1) random real number with 53bit resolution
   double next_double(){
     uint32_t a=g.next()>>5;
@@ -95,6 +100,23 @@ public:
   /// generate [\a a,\a b) random real number
   double next_double(double a, double b){
     return a+next_double(b-a);
+  }
+
+  /// generate normalized standard distribution
+  float next_gaussian_float(){
+    static const float pi2 = (float)(2.0 * jubatus::util::math::pi);
+    if(next_gaussian_stocked){
+      next_gaussian_stocked=false;
+      return (float)next_gaussian_stock;
+    }else{
+      float a = 1.0f-next_float();
+      float b = 1.0f-next_float();
+      float r1 = std::sqrt(-2.0f*std::log(a))*std::sin(pi2*b);
+      float r2 = std::sqrt(-2.0f*std::log(a))*std::cos(pi2*b);
+      next_gaussian_stock=r2;
+      next_gaussian_stocked=true;
+      return r1;
+    }
   }
 
   /// generate normalized standard distribution

--- a/jubatus/util/math/random/sfmt.h
+++ b/jubatus/util/math/random/sfmt.h
@@ -1,0 +1,283 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2016 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+/*
+SFMT implementation is based official code.
+(http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/SFMT/index.html)
+
+Changes:
+* uses c++ template to switch sfmt parameters
+* remove non-SSE2, Big-Endian code
+
+Copyright (c) 2006,2007 Mutsuo Saito, Makoto Matsumoto and Hiroshima
+University.
+Copyright (c) 2012 Mutsuo Saito, Makoto Matsumoto, Hiroshima University
+and The University of Tokyo.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the names of Hiroshima University, The University of
+      Tokyo nor the names of its contributors may be used to endorse
+      or promote products derived from this software without specific
+      prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef JUBATUS_UTIL_MATH_RANDOM_SFMT_H_
+#define JUBATUS_UTIL_MATH_RANDOM_SFMT_H_
+#include <cstring>
+#include <stdint.h>
+
+#ifdef __SSE2__
+#include <emmintrin.h>
+#endif
+
+namespace jubatus {
+namespace util{
+namespace math{
+namespace random{
+
+#ifndef __SSE2__
+typedef uint32_t __m128i[4];
+#endif
+
+template<uint32_t MEXP, int POS1, int SL1, int SL2, int SR1, int SR2,
+         uint32_t MSK1, uint32_t MSK2, uint32_t MSK3, uint32_t MSK4,
+         uint32_t PARITY1, uint32_t PARITY2, uint32_t PARITY3, uint32_t PARITY4>
+class sfmt {
+  static const uint32_t N = MEXP / 128 + 1;
+  static const uint32_t N32 = N * 4;
+  union {
+    uint32_t u[4];
+    uint64_t u64[2];
+    __m128i si;
+  } s[N];
+  uint64_t idx;
+
+public:
+  sfmt(uint32_t seed) : idx(N32) {
+    static const uint32_t parity[4] = {PARITY1, PARITY2, PARITY3, PARITY4};
+    uint32_t *psfmt32 = &(s[0].u[0]);
+    psfmt32[0] = seed;
+    for (uint32_t i = 1; i < N32; i++) {
+      psfmt32[i] = 1812433253UL * (psfmt32[i - 1] ^ (psfmt32[i - 1] >> 30)) + i;
+    }
+
+    //period_certification
+    int inner = 0;
+    for (int i = 0; i < 4; i++)
+      inner ^= psfmt32[i] & parity[i];
+    for (int i = 16; i > 0; i >>= 1)
+      inner ^= inner >> i;
+    inner &= 1;
+    if (inner == 1)
+      return;
+    for (int i = 0; i < 4; i++) {
+      int work = 1;
+      for (int j = 0; j < 32; j++) {
+        if ((work & parity[i]) != 0) {
+          psfmt32[i] ^= work;
+          return;
+        }
+        work = work << 1;
+      }
+    }
+  }
+  ~sfmt() {}
+
+  uint32_t next() {
+    uint32_t *psfmt32 = &(s[0].u[0]);
+    if (idx >= N32) {
+      generate_all();
+      idx = 0;
+    }
+    return psfmt32[idx++];
+  }
+
+  void fill_int_unsafe(uint32_t *out, size_t n) {
+    uint32_t *psfmt32 = &(s[0].u[0]);
+    if (idx + n <= N32) {
+      std::memcpy(out, psfmt32 + idx, n * sizeof(uint32_t));
+      idx += n;
+    } else {
+      while (n > 0) {
+        if (idx >= N32) {
+          generate_all();
+          idx = 0;
+        }
+        size_t m = (n + idx <= N32 ? n : N32 - idx);
+        std::memcpy(out, psfmt32 + idx, m * sizeof(uint32_t));
+        idx += m;
+        out += m;
+        n -= m;
+      }
+    }
+  }
+private:
+
+#ifdef __SSE2__
+
+  inline static void mm_recursion(__m128i * r, __m128i a, __m128i b,
+                                  __m128i c, __m128i d) {
+    static const uint32_t sse2_param_mask[4] __attribute__((aligned(16)))
+      = {MSK1, MSK2, MSK3, MSK4};
+    __m128i v, x, y, z;
+    y = _mm_srli_epi32(b, SR1);
+    z = _mm_srli_si128(c, SR2);
+    v = _mm_slli_epi32(d, SL1);
+    z = _mm_xor_si128(z, a);
+    z = _mm_xor_si128(z, v);
+    x = _mm_slli_si128(a, SL2);
+    y = _mm_and_si128(y, *(const __m128i*)sse2_param_mask);
+    z = _mm_xor_si128(z, x);
+    z = _mm_xor_si128(z, y);
+    *r = z;
+  }
+
+  void generate_all() {
+    uint32_t i;
+    __m128i r1, r2;
+    r1 = s[N - 2].si;
+    r2 = s[N - 1].si;
+    for (i = 0; i < N - POS1; i++) {
+      mm_recursion(&s[i].si, s[i].si, s[i + POS1].si, r1, r2);
+      r1 = r2;
+      r2 = s[i].si;
+    }
+    for (; i < N; i++) {
+      mm_recursion(&s[i].si, s[i].si, s[i + POS1 - N].si, r1, r2);
+      r1 = r2;
+      r2 = s[i].si;
+    }
+  }
+
+#else // #ifdef __SSE2__
+
+  inline static void mm_recursion(__m128i * r, __m128i a, __m128i b,
+                                  __m128i c, __m128i d) {
+    __m128i x, y;
+    {
+      uint64_t th, tl, oh, ol;
+      th = ((uint64_t)a[3] << 32) | ((uint64_t)a[2]);
+      tl = ((uint64_t)a[1] << 32) | ((uint64_t)a[0]);
+      oh = th << (SL2 * 8);
+      ol = tl << (SL2 * 8);
+      oh |= tl >> (64 - SL2 * 8);
+      x[1] = (uint32_t)(ol >> 32);
+      x[0] = (uint32_t)ol;
+      x[3] = (uint32_t)(oh >> 32);
+      x[2] = (uint32_t)oh;
+    }
+    {
+      uint64_t th, tl, oh, ol;
+      th = ((uint64_t)c[3] << 32) | ((uint64_t)c[2]);
+      tl = ((uint64_t)c[1] << 32) | ((uint64_t)c[0]);
+      oh = th >> (SR2 * 8);
+      ol = tl >> (SR2 * 8);
+      ol |= th << (64 - SR2 * 8);
+      y[1] = (uint32_t)(ol >> 32);
+      y[0] = (uint32_t)ol;
+      y[3] = (uint32_t)(oh >> 32);
+      y[2] = (uint32_t)oh;
+    }
+    (*r)[0] = a[0] ^ x[0] ^ ((b[0] >> SR1) & MSK1) ^ y[0] ^ (d[0] << SL1);
+    (*r)[1] = a[1] ^ x[1] ^ ((b[1] >> SR1) & MSK2) ^ y[1] ^ (d[1] << SL1);
+    (*r)[2] = a[2] ^ x[2] ^ ((b[2] >> SR1) & MSK3) ^ y[2] ^ (d[2] << SL1);
+    (*r)[3] = a[3] ^ x[3] ^ ((b[3] >> SR1) & MSK4) ^ y[3] ^ (d[3] << SL1);
+  }
+
+  static inline void memcpy_m128i(__m128i dst, const __m128i src) {
+    dst[0] = src[0]; dst[1] = src[1];
+    dst[2] = src[2]; dst[3] = src[3];
+  }
+
+  void generate_all() {
+    uint32_t i;
+    __m128i r1, r2;
+    memcpy_m128i(r1, s[N - 2].si);
+    memcpy_m128i(r2, s[N - 1].si);
+    for (i = 0; i < N - POS1; i++) {
+      mm_recursion(&s[i].si, s[i].si, s[i + POS1].si, r1, r2);
+      memcpy_m128i(r1, r2);
+      memcpy_m128i(r2, s[i].si);
+    }
+    for (; i < N; i++) {
+      mm_recursion(&s[i].si, s[i].si, s[i + POS1 - N].si, r1, r2);
+      memcpy_m128i(r1, r2);
+      memcpy_m128i(r2, s[i].si);
+    }
+  }
+
+#endif // #ifdef __SSE2__
+};
+
+typedef sfmt<607, 2, 15, 3, 13, 3,
+             0xfdff37ffU, 0xef7f3f7dU, 0xff777b7dU, 0x7ff7fb2fU,
+             0x00000001U, 0x00000000U, 0x00000000U, 0x5986f054U> sfmt607;
+typedef sfmt<1279, 7, 14, 3, 5, 1,
+             0xf7fefffdU, 0x7fefcfffU, 0xaff3ef3fU, 0xb5ffff7fU,
+             0x00000001U, 0x00000000U, 0x00000000U, 0x20000000U> sfmt1279;
+typedef sfmt<2281, 12, 19, 1, 5, 1,
+             0xbff7ffbfU, 0xfdfffffeU, 0xf7ffef7fU, 0xf2f7cbbfU,
+             0x00000001U, 0x00000000U, 0x00000000U, 0x41dfa600U> sfmt2281;
+typedef sfmt<4253, 17, 20, 1, 7, 1,
+             0x9f7bffffU, 0x9fffff5fU, 0x3efffffbU, 0xfffff7bbU,
+             0xa8000001U, 0xaf5390a3U, 0xb740b3f8U, 0x6c11486dU> sfmt4253;
+typedef sfmt<11213, 68, 14, 3, 7, 3,
+             0xeffff7fbU, 0xffffffefU, 0xdfdfbfffU, 0x7fffdbfdU,
+             0x00000001U, 0x00000000U, 0xe8148000U, 0xd0c7afa3U> sfmt11213;
+typedef sfmt<19937, 122, 18, 1, 11, 1,
+             0xdfffffefU, 0xddfecb7fU, 0xbffaffffU, 0xbffffff6U,
+             0x00000001U, 0x00000000U, 0x00000000U, 0x13c9e684U> sfmt19937;
+typedef sfmt<44497, 330, 5, 3, 9, 3,
+             0xeffffffbU, 0xdfbebfffU, 0xbfbf7befU, 0x9ffd7bffU,
+             0x00000001U, 0x00000000U, 0xa3ac4000U, 0xecc1327aU> sfmt44497;
+typedef sfmt<86243, 366, 6, 7, 19, 1,
+             0xfdbffbffU, 0xbff7ff3fU, 0xfd77efffU, 0xbf9ff3ffU,
+             0x00000001U, 0x00000000U, 0x00000000U, 0xe9528d85U> sfmt86243;
+typedef sfmt<132049, 110, 19, 1, 21, 1,
+             0xffffbb5fU, 0xfb6ebf95U, 0xfffefffaU, 0xcff77fffU,
+             0x00000001U, 0x00000000U, 0xcb520000U, 0xc7e91c7dU> sfmt132049;
+typedef sfmt<216091, 627, 11, 3, 10, 1,
+             0xbff7bff7U, 0xbfffffffU, 0xbffffa7fU, 0xffddfbfbU,
+             0xf8000001U, 0x89e80709U, 0x3bd2b64bU, 0x0c64b1e4U> sfmt216091;
+
+} // random
+} // math
+} // util
+} // jubatus
+
+#endif  // #ifndef JUBATUS_UTIL_MATH_RANDOM_SFMT_H_

--- a/jubatus/util/math/random_test.cpp
+++ b/jubatus/util/math/random_test.cpp
@@ -214,3 +214,16 @@ TEST(random, sampling_without_replacement) {
     }
   }
 }
+
+
+TEST(random, sfmt607_test) {
+  // Test vectors from SFMT official implementation (v1.4.1)
+  jubatus::util::math::random::sfmt607 r(1234);
+  uint32_t expected_values[] = {
+    1196421539, 2865311212, 3866479472, 2692900087, 3838928621,
+    3188765817, 2751632982, 3712143069,  549918413, 2026167923
+  };
+  for (int i = 0; i < 10; ++i) {
+    EXPECT_EQ(expected_values[i], r.next());
+  }
+}

--- a/jubatus/util/math/wscript
+++ b/jubatus/util/math/wscript
@@ -8,6 +8,7 @@ def build(bld):
       'random.h',
       'random/license.h',
       'random/mersenne_twister.h',
+      'random/sfmt.h',
       'vector.h',
       'fft.h',
       ], relative_trick = True)

--- a/wscript
+++ b/wscript
@@ -84,6 +84,22 @@ def configure(conf):
   if conf.env.USE_EIGEN:
     conf.define('JUBATUS_USE_EIGEN', 1)
 
+  func_multiver_test_code = '''#include <immintrin.h>
+__attribute__((target("default"))) void test() {}
+__attribute__((target("sse2"))) void test() { __m128i x; _mm_xor_si128(x,x); }
+__attribute__((target("avx2"))) void test() { __m256i x; _mm256_xor_si256(x,x); }
+int main() { test(); }
+'''
+  func_multiver_enabled = conf.check_cxx(
+    fragment=func_multiver_test_code,
+    msg='Checking for function multiversioning',
+    execute=True,
+    mandatory=False,
+    define_name='JUBATUS_USE_FMV')
+  if not func_multiver_enabled:
+    sse2_test_code = '#ifdef __SSE2__\nint main() {}\n#else\n#error\n#endif'
+    conf.check_cxx(fragment=sse2_test_code, msg='Checking for sse2', mandatory=False)
+
   conf.recurse(subdirs)
 
 def build(bld):


### PR DESCRIPTION
NNで利用するrandom_projectionをSSE2/AVX2により高速化しました．

過去のバージョンが作成するモデルとの互換性がなくなっている他，
精度にも影響を与える変更を加えています．

最終的には以下のように10倍以上高速になりました．
* iris: 3.49319 => 0.214638 [ms/train]
* dorothea: 782.344 => 37.9593 [ms/train]
* 20news: 145.126 => 7.2572 [ms/train]

各コミットの補足です．

1. 正規分布の浮動小数点型を倍精度から単精度に変更しました．
random_projectionでは符号しか利用しないため，単精度にしても精度に与える影響は少ないと考えています． (詳細はコミットメッセージのaccuracyを参照ください)
2. SSE2/AVX2を用いて一度に8個/16個の正規分布に基づく乱数を生成するようにしました
3. 乱数生成器をMT19937からSFMT607にしました．MT19937はスループットは良いのですが状態が大きく初期化が重いため，random_projectionのように特徴量毎に初期化する必要がある場合は状態が少ない607程度で良いようです．またxorshift128+のように更に状態が少ないものも有りますがこちらはスループットが良くないので，MT/SFMTの各周期，xorshift128+を評価した結果もっとも性能が良かったSFMT607を採用しました．

related issue: #244