### PR TITLE
NN parallel search/random_projection implementation

### DIFF
--- a/jubatus/core/common/thread_pool.cpp
+++ b/jubatus/core/common/thread_pool.cpp
@@ -1,0 +1,70 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2016 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+#include "thread_pool.hpp"
+#include <vector>
+
+using jubatus::util::concurrent::scoped_lock;
+using jubatus::util::lang::function;
+using jubatus::util::lang::shared_ptr;
+
+namespace jubatus {
+namespace core {
+namespace common {
+
+thread_pool::thread_pool(int max_threads)
+  : pool_(), queue_(), mutex_(), cond_(), shutdown_(false) {
+  if (max_threads < 0)
+    max_threads = thread::hardware_concurrency();
+  pool_.reserve(max_threads);
+}
+
+thread_pool::~thread_pool() {
+  {
+    scoped_lock lk(mutex_);
+    this->shutdown_ = true;
+    cond_.notify_all();
+  }
+  for (std::vector<shared_ptr<thread> >::iterator it = pool_.begin();
+       it != pool_.end(); ++it) {
+    (*it)->join();
+  }
+}
+
+void thread_pool::worker(thread_pool *tp) {
+  while (true) {
+    function<void()> task;
+    {
+      scoped_lock lk(tp->mutex_);
+      while (tp->queue_.empty()) {
+        if (tp->shutdown_)
+          return;
+        tp->cond_.wait(tp->mutex_);
+      }
+      task = tp->queue_.front();
+      tp->queue_.pop();
+    }
+    task();
+  }
+}
+
+namespace default_thread_pool {
+  thread_pool instance(-1);
+}
+
+}  // namespace common
+}  // namespace core
+}  // namespace jubatus

--- a/jubatus/core/common/thread_pool.hpp
+++ b/jubatus/core/common/thread_pool.hpp
@@ -1,0 +1,178 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2016 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+#ifndef JUBATUS_CORE_COMMON_THREAD_POOL_HPP_
+#define JUBATUS_CORE_COMMON_THREAD_POOL_HPP_
+
+#include <jubatus/util/concurrent/condition.h>
+#include <jubatus/util/concurrent/mutex.h>
+#include <jubatus/util/concurrent/lock.h>
+#include <jubatus/util/concurrent/thread.h>
+#include <jubatus/util/lang/bind.h>
+#include <jubatus/util/lang/function.h>
+#include <jubatus/util/lang/shared_ptr.h>
+
+#include <queue>
+#include <vector>
+
+namespace jubatus {
+namespace core {
+namespace common {
+
+class thread_pool {
+  typedef jubatus::util::concurrent::mutex mutex;
+  typedef jubatus::util::concurrent::condition condition;
+  typedef jubatus::util::concurrent::thread thread;
+  typedef jubatus::util::concurrent::scoped_lock scoped_lock;
+
+ public:
+  explicit thread_pool(int max_threads);
+  ~thread_pool();
+
+  template<typename T>
+  class future {
+  public:
+    explicit future(const jubatus::util::lang::function<T()>& func)
+      : func_(func), ret_(), mutex_(), cond_(), finished_(false) {}
+
+    const T& get() const {
+      scoped_lock lk(mutex_);
+      while (!finished_)
+        cond_.wait(mutex_);
+      return ret_;
+    }
+
+  private:
+    void execute() {
+      ret_ = func_();
+      {
+        jubatus::util::concurrent::scoped_lock lk(mutex_);
+        finished_ = true;
+        cond_.notify_all();
+      }
+    }
+
+    const jubatus::util::lang::function<T()> func_;
+    T ret_;
+    mutable mutex mutex_;
+    mutable condition cond_;
+    bool finished_;
+
+    friend class thread_pool;
+
+    future(const future&);
+    future& operator =(const future&);
+  };
+
+  template<typename Function>
+  jubatus::util::lang::shared_ptr<future<typename Function::result_type> >
+  async(Function f) {
+    using jubatus::util::lang::bind;
+    using jubatus::util::lang::shared_ptr;
+    typedef typename Function::result_type R;
+    shared_ptr<future<R> >fut(new future<R>(f));
+    if (pool_.capacity() == 0) {
+      fut->execute();
+    } else {
+      scoped_lock lk(mutex_);
+      const bool empty_flag = queue_.empty();
+      queue_.push(bind(&wrapper<R>, fut.get()));
+      if (pool_.size() < pool_.capacity()) {
+        shared_ptr<thread> th(new thread(bind(&worker, this)));
+        th->start();
+        pool_.push_back(th);
+      } else if (empty_flag) {
+        cond_.notify_all();
+      }
+    }
+    return fut;
+  }
+
+  template<typename Function>
+  std::vector<
+    jubatus::util::lang::shared_ptr<
+      future<typename Function::result_type> > >
+  async_all(const std::vector<Function>& funcs) {
+    using jubatus::util::lang::bind;
+    using jubatus::util::lang::shared_ptr;
+    typedef typename Function::result_type R;
+    typedef typename std::vector<Function>::const_iterator Iter;
+    typedef typename std::vector<shared_ptr<future<R> > >::iterator RIter;
+
+    std::vector<shared_ptr<future<R> > > ret;
+    ret.reserve(funcs.size());
+
+    for (Iter it = funcs.begin(); it != funcs.end(); ++it)
+      ret.push_back(shared_ptr<future<R> >(new future<R>(*it)));
+
+    if (pool_.capacity() == 0) {
+      for (RIter it = ret.begin(); it != ret.end(); ++it)
+        (*it)->execute();
+    } else {
+      scoped_lock lk(mutex_);
+      const bool empty_flag = queue_.empty();
+      for (RIter it = ret.begin(); it != ret.end(); ++it)
+        queue_.push(bind(&wrapper<R>, (*it).get()));
+      while (pool_.size() < pool_.capacity() && pool_.size() < queue_.size()) {
+        shared_ptr<thread> th(new thread(bind(&worker, this)));
+        th->start();
+        pool_.push_back(th);
+      }
+      if (empty_flag)
+        cond_.notify_all();
+    }
+    return ret;
+  }
+
+ private:
+  template<typename T>
+  static void wrapper(future<T> *fut) {
+    fut->execute();
+  }
+
+  static void worker(thread_pool *tp);
+
+  std::vector<jubatus::util::lang::shared_ptr<thread> > pool_;
+  std::queue<jubatus::util::lang::function<void()> > queue_;
+  mutex mutex_;
+  condition cond_;
+  bool shutdown_;
+};
+
+namespace default_thread_pool {
+  extern thread_pool instance;
+
+  template<typename Function>
+  jubatus::util::lang::shared_ptr<
+    thread_pool::future<typename Function::result_type> >
+  async(Function f) {
+    return instance.async(f);
+  }
+
+  template<typename Function>
+  std::vector<
+    jubatus::util::lang::shared_ptr<
+      thread_pool::future<typename Function::result_type> > >
+  async_all(const std::vector<Function>& funcs) {
+    return instance.async_all(funcs);
+  }
+}
+
+}  // namespace common
+}  // namespace core
+}  // namespace jubatus
+
+#endif  // #ifndef JUBATUS_CORE_COMMON_THREAD_POOL_HPP_

--- a/jubatus/core/common/wscript
+++ b/jubatus/core/common/wscript
@@ -9,6 +9,7 @@ def build(bld):
   source = [
       'exception.cpp',
       'key_manager.cpp',
+      'thread_pool.cpp',
       'vector_util.cpp',
       'version.cpp',
       'jsonconfig/config.cpp',
@@ -25,6 +26,7 @@ def build(bld):
       'hash.hpp',
       'jsonconfig.hpp',
       'key_manager.hpp',
+      'thread_pool.hpp',
       'type.hpp',
       'unordered_map.hpp',
       'vector_util.hpp',

--- a/jubatus/core/nearest_neighbor/bit_vector_nearest_neighbor_base.cpp
+++ b/jubatus/core/nearest_neighbor/bit_vector_nearest_neighbor_base.cpp
@@ -41,7 +41,7 @@ bit_vector_nearest_neighbor_base::bit_vector_nearest_neighbor_base(
     jubatus::util::lang::shared_ptr<storage::column_table> table,
     const std::string& id)
     : nearest_neighbor_base(table, id),
-      bitnum_(bitnum) {
+      bitnum_(bitnum), threads_(0) {
   vector<column_type> schema;
   fill_schema(schema);
   table->init(schema);
@@ -53,7 +53,7 @@ bit_vector_nearest_neighbor_base::bit_vector_nearest_neighbor_base(
     vector<column_type>& schema,
     const std::string& id)
     : nearest_neighbor_base(table, id),
-      bitnum_(bitnum) {
+      bitnum_(bitnum), threads_(0) {
   fill_schema(schema);
 }
 
@@ -116,7 +116,8 @@ void bit_vector_nearest_neighbor_base::neighbor_row_from_hash(
   // take lock out of this function
   vector<pair<uint64_t, float> > scores;
 
-  ranking_hamming_bit_vectors(query, bit_vector_column(), scores, ret_num);
+  ranking_hamming_bit_vectors(
+    query, bit_vector_column(), scores, ret_num, threads_);
 
   jubatus::util::lang::shared_ptr<const column_table> table = get_const_table();
   ids.clear();

--- a/jubatus/core/nearest_neighbor/bit_vector_nearest_neighbor_base.hpp
+++ b/jubatus/core/nearest_neighbor/bit_vector_nearest_neighbor_base.hpp
@@ -68,6 +68,9 @@ class bit_vector_nearest_neighbor_base : public nearest_neighbor_base {
 
   uint64_t bit_vector_column_id_;
   uint32_t bitnum_;
+
+ protected:
+  uint32_t threads_;
 };
 
 }  // namespace nearest_neighbor

--- a/jubatus/core/nearest_neighbor/bit_vector_ranking.cpp
+++ b/jubatus/core/nearest_neighbor/bit_vector_ranking.cpp
@@ -38,7 +38,8 @@ void ranking_hamming_bit_vectors(
     uint64_t ret_num) {
   storage::fixed_size_heap<pair<uint32_t, uint64_t> > heap(ret_num);
   for (uint64_t i = 0; i < bvs.size(); ++i) {
-    const size_t dist = query.calc_hamming_distance(bvs[i]);
+    const size_t dist =
+        query.calc_hamming_distance_unsafe(bvs.get_data_at_unsafe(i));
     heap.push(make_pair(dist, i));
   }
 

--- a/jubatus/core/nearest_neighbor/bit_vector_ranking.hpp
+++ b/jubatus/core/nearest_neighbor/bit_vector_ranking.hpp
@@ -18,8 +18,11 @@
 #define JUBATUS_CORE_NEAREST_NEIGHBOR_BIT_VECTOR_RANKING_HPP_
 
 #include <stdint.h>
+#include <algorithm>
+#include <cmath>
 #include <utility>
 #include <vector>
+#include "jubatus/core/common/thread_pool.hpp"
 
 namespace jubatus {
 namespace core {
@@ -38,7 +41,43 @@ void ranking_hamming_bit_vectors(
     const storage::bit_vector& query,
     const storage::const_bit_vector_column& bvs,
     std::vector<std::pair<uint64_t, float> >& ret,
-    uint64_t ret_num);
+    uint64_t ret_num, uint32_t threads);
+
+template <typename Function, typename THeap>
+void ranking_hamming_bit_vectors_internal(
+    Function& f, size_t size, uint32_t threads, THeap& heap) {
+  typedef std::vector<
+    jubatus::util::lang::shared_ptr<
+      jubatus::core::common::thread_pool::future<THeap> > > future_list_t;
+  if (threads > 1) {
+    size_t block_size = static_cast<size_t>(
+      std::ceil(size / static_cast<float>(threads)));
+    std::vector<jubatus::util::lang::function<THeap()> > funcs;
+    funcs.reserve(size / block_size + 1);
+    for (size_t t = 0, end = 0; t < threads && end < size ; ++t) {
+      size_t off = end;
+      end += std::min(block_size, size - off);
+      funcs.push_back(jubatus::util::lang::bind(f, off, end));
+    }
+    future_list_t futures =
+      jubatus::core::common::default_thread_pool::async_all(funcs);
+    for (typename future_list_t::iterator it = futures.begin();
+         it != futures.end(); ++it) {
+      heap.merge((*it)->get());
+    }
+  } else {
+    heap.merge(f(0, size));
+  }
+}
+
+template <typename T>
+uint32_t read_threads_config(T& cfg) {
+  if (!cfg.bool_test())
+    return 0;
+  if (*cfg < 0)
+    return jubatus::util::concurrent::thread::hardware_concurrency();
+  return static_cast<uint32_t>(*cfg);
+}
 
 }  // namespace nearest_neighbor
 }  // namespace core

--- a/jubatus/core/nearest_neighbor/euclid_lsh.cpp
+++ b/jubatus/core/nearest_neighbor/euclid_lsh.cpp
@@ -150,7 +150,8 @@ void euclid_lsh::neighbor_row_from_hash(
 
     const float denom = bv.bit_num();
     for (size_t i = 0; i < table->size(); ++i) {
-      const size_t hamm_dist = bv.calc_hamming_distance(bv_col[i]);
+      const size_t hamm_dist =
+          bv.calc_hamming_distance_unsafe(bv_col.get_data_at_unsafe(i));
       const float theta = hamm_dist * M_PI / denom;
       const float score =
           norm_col[i] * (norm_col[i] - 2 * norm * std::cos(theta));

--- a/jubatus/core/nearest_neighbor/euclid_lsh.cpp
+++ b/jubatus/core/nearest_neighbor/euclid_lsh.cpp
@@ -86,7 +86,8 @@ euclid_lsh::euclid_lsh(
 void euclid_lsh::set_row(const string& id, const common::sfv_t& sfv) {
   // TODO(beam2d): support nested algorithm, e.g. when used by lof and then we
   // cannot suppose that the first two columns are assigned to euclid_lsh.
-  get_table()->add(id, owner(my_id_), cosine_lsh(sfv, hash_num_), l2norm(sfv));
+  get_table()->add(id, owner(my_id_),
+                   cosine_lsh(sfv, hash_num_, threads_), l2norm(sfv));
 }
 
 void euclid_lsh::neighbor_row(
@@ -94,7 +95,7 @@ void euclid_lsh::neighbor_row(
     vector<pair<string, float> >& ids,
     uint64_t ret_num) const {
   neighbor_row_from_hash(
-      cosine_lsh(query, hash_num_),
+      cosine_lsh(query, hash_num_, threads_),
       l2norm(query),
       ids,
       ret_num);

--- a/jubatus/core/nearest_neighbor/euclid_lsh.cpp
+++ b/jubatus/core/nearest_neighbor/euclid_lsh.cpp
@@ -25,6 +25,7 @@
 #include "../storage/fixed_size_heap.hpp"
 #include "../storage/column_table.hpp"
 #include "lsh_function.hpp"
+#include "bit_vector_ranking.hpp"
 
 using std::map;
 using std::pair;
@@ -38,6 +39,8 @@ using jubatus::core::storage::owner;
 using jubatus::core::storage::bit_vector;
 using jubatus::core::storage::const_bit_vector_column;
 using jubatus::core::storage::const_float_column;
+
+typedef jubatus::core::storage::fixed_size_heap<pair<float, size_t> > heap_t;
 
 namespace jubatus {
 namespace core {
@@ -118,8 +121,8 @@ void euclid_lsh::set_config(const config& conf) {
     throw JUBATUS_EXCEPTION(
         common::invalid_parameter("1 <= hash_num"));
   }
-
   hash_num_ = conf.hash_num;
+  threads_ = read_threads_config(conf.threads);
 }
 
 void euclid_lsh::fill_schema(vector<column_type>& schema) {
@@ -136,28 +139,39 @@ const_float_column& euclid_lsh::norm_column() const {
   return get_const_table()->get_float_column(first_column_id_ + 1);
 }
 
+static heap_t ranking_hamming_bit_vectors_worker(
+    const bit_vector *bv, const_bit_vector_column *bv_col,
+    const_float_column *norm_col, float denom, float norm,
+    uint64_t ret_num, size_t off, size_t end) {
+  heap_t heap(ret_num);
+  for (size_t i = off; i < end; ++i) {
+    const size_t hamm_dist =
+      bv->calc_hamming_distance_unsafe(bv_col->get_data_at_unsafe(i));
+    const float theta = hamm_dist * M_PI / denom;
+    const float score =
+      (*norm_col)[i] * ((*norm_col)[i] - 2 * norm * std::cos(theta));
+    heap.push(make_pair(score, i));
+  }
+  return heap;
+}
+
 void euclid_lsh::neighbor_row_from_hash(
     const bit_vector& bv,
     float norm,
     vector<pair<string, float> >& ids,
     uint64_t ret_num) const {
-  jubatus::util::lang::shared_ptr<const column_table> table = get_const_table();
-
-  jubatus::core::storage::fixed_size_heap<pair<float, size_t> > heap(ret_num);
-  {
-    const_bit_vector_column& bv_col = lsh_column();
-    const_float_column& norm_col = norm_column();
-
-    const float denom = bv.bit_num();
-    for (size_t i = 0; i < table->size(); ++i) {
-      const size_t hamm_dist =
-          bv.calc_hamming_distance_unsafe(bv_col.get_data_at_unsafe(i));
-      const float theta = hamm_dist * M_PI / denom;
-      const float score =
-          norm_col[i] * (norm_col[i] - 2 * norm * std::cos(theta));
-      heap.push(make_pair(score, i));
-    }
-  }
+  jubatus::util::lang::shared_ptr<const column_table> table =
+    get_const_table();
+  const_bit_vector_column& bv_col = lsh_column();
+  const_float_column& norm_col = norm_column();
+  const float denom = bv.bit_num();
+  heap_t heap(ret_num);
+  jubatus::util::lang::function<heap_t(size_t, size_t)> f =
+    jubatus::util::lang::bind(
+      &ranking_hamming_bit_vectors_worker, &bv, &bv_col, &norm_col,
+      denom, norm, ret_num,
+      jubatus::util::lang::_1, jubatus::util::lang::_2);
+  ranking_hamming_bit_vectors_internal(f, table->size(), threads_, heap);
 
   vector<pair<float, size_t> > sorted;
   heap.get_sorted(sorted);

--- a/jubatus/core/nearest_neighbor/euclid_lsh.hpp
+++ b/jubatus/core/nearest_neighbor/euclid_lsh.hpp
@@ -22,6 +22,7 @@
 #include <utility>
 #include <vector>
 #include "jubatus/util/data/serialization.h"
+#include "jubatus/util/data/optional.h"
 #include "jubatus/util/lang/shared_ptr.h"
 #include "nearest_neighbor_base.hpp"
 
@@ -36,15 +37,16 @@ class euclid_lsh : public nearest_neighbor_base {
  public:
   struct config {
     config()
-        : hash_num(64u) {
+        : hash_num(64u), threads() {
     }
 
     // TODO(beam2d): make it uint32_t (by modifying pficommon)
     int32_t hash_num;
+    jubatus::util::data::optional<int32_t> threads;
 
     template <typename Ar>
     void serialize(Ar& ar) {
-      ar & JUBA_MEMBER(hash_num);
+      ar & JUBA_MEMBER(hash_num) & JUBA_MEMBER(threads);
     }
   };
 
@@ -90,6 +92,7 @@ class euclid_lsh : public nearest_neighbor_base {
 
   uint64_t first_column_id_;
   uint32_t hash_num_;
+  uint32_t threads_;
 };
 
 }  // namespace nearest_neighbor_base

--- a/jubatus/core/nearest_neighbor/lsh.cpp
+++ b/jubatus/core/nearest_neighbor/lsh.cpp
@@ -46,7 +46,7 @@ lsh::lsh(
 }
 
 storage::bit_vector lsh::hash(const common::sfv_t& sfv) const {
-  return cosine_lsh(sfv, bitnum());
+  return cosine_lsh(sfv, bitnum(), threads_);
 }
 
 void lsh::set_config(const config& conf) {

--- a/jubatus/core/nearest_neighbor/lsh.cpp
+++ b/jubatus/core/nearest_neighbor/lsh.cpp
@@ -19,6 +19,7 @@
 #include <vector>
 #include "lsh.hpp"
 #include "lsh_function.hpp"
+#include "bit_vector_ranking.hpp"
 #include "../storage/column_table.hpp"
 
 namespace jubatus {
@@ -31,10 +32,7 @@ lsh::lsh(
     const std::string& id)
     : bit_vector_nearest_neighbor_base(conf.hash_num, table, id) {
 
-  if (!(1 <= conf.hash_num)) {
-    throw JUBATUS_EXCEPTION(
-        common::invalid_parameter("1 <= hash_num"));
-  }
+  set_config(conf);
 }
 
 lsh::lsh(
@@ -44,14 +42,19 @@ lsh::lsh(
     const std::string& id)
     : bit_vector_nearest_neighbor_base(conf.hash_num, table, schema, id) {
 
-  if (!(1 <= conf.hash_num)) {
-    throw JUBATUS_EXCEPTION(
-        common::invalid_parameter("1 <= hash_num"));
-  }
+  set_config(conf);
 }
 
 storage::bit_vector lsh::hash(const common::sfv_t& sfv) const {
   return cosine_lsh(sfv, bitnum());
+}
+
+void lsh::set_config(const config& conf) {
+  if (!(1 <= conf.hash_num)) {
+    throw JUBATUS_EXCEPTION(
+        common::invalid_parameter("1 <= hash_num"));
+  }
+  threads_ = read_threads_config(conf.threads);
 }
 
 }  // namespace nearest_neighbor

--- a/jubatus/core/nearest_neighbor/lsh.hpp
+++ b/jubatus/core/nearest_neighbor/lsh.hpp
@@ -21,6 +21,7 @@
 #include <string>
 #include <vector>
 #include "jubatus/util/data/serialization.h"
+#include "jubatus/util/data/optional.h"
 #include "jubatus/util/lang/shared_ptr.h"
 #include "bit_vector_nearest_neighbor_base.hpp"
 
@@ -34,14 +35,15 @@ namespace nearest_neighbor {
 class lsh : public bit_vector_nearest_neighbor_base {
  public:
   struct config {
-    config() : hash_num(64u) {
+    config() : hash_num(64u), threads() {
     }
 
     int32_t hash_num;
+    jubatus::util::data::optional<int32_t> threads;
 
     template <typename Ar>
     void serialize(Ar& ar) {
-      ar & JUBA_MEMBER(hash_num);
+      ar & JUBA_MEMBER(hash_num) & JUBA_MEMBER(threads);
     }
   };
   lsh(const config& conf,
@@ -56,6 +58,7 @@ class lsh : public bit_vector_nearest_neighbor_base {
 
  private:
   virtual storage::bit_vector hash(const common::sfv_t& sfv) const;
+  void set_config(const config& conf);
 };
 
 }  // namespace nearest_neighbor

--- a/jubatus/core/nearest_neighbor/lsh_function.hpp
+++ b/jubatus/core/nearest_neighbor/lsh_function.hpp
@@ -28,9 +28,10 @@ namespace nearest_neighbor {
 
 std::vector<float> random_projection(
     const common::sfv_t& sfv,
-    uint32_t hash_num);
+    uint32_t hash_num, uint32_t threads);
 storage::bit_vector binarize(const std::vector<float>& proj);
-storage::bit_vector cosine_lsh(const common::sfv_t& sfv, uint32_t hash_num);
+storage::bit_vector cosine_lsh(
+    const common::sfv_t& sfv, uint32_t hash_num, uint32_t threads);
 
 }  // namespace nearest_neighbor
 }  // namespace core

--- a/jubatus/core/nearest_neighbor/minhash.cpp
+++ b/jubatus/core/nearest_neighbor/minhash.cpp
@@ -20,8 +20,8 @@
 #include <map>
 #include <string>
 #include <vector>
-
 #include "../common/hash.hpp"
+#include "bit_vector_ranking.hpp"
 
 using std::string;
 using std::map;
@@ -106,10 +106,7 @@ minhash::minhash(
     const std::string& id)
     : bit_vector_nearest_neighbor_base(conf.hash_num, table, id) {
 
-  if (!(1 <= conf.hash_num)) {
-    throw JUBATUS_EXCEPTION(
-        common::invalid_parameter("1 <= hash_num"));
-  }
+  set_config(conf);
 }
 
 minhash::minhash(
@@ -119,10 +116,7 @@ minhash::minhash(
     const std::string& id)
     : bit_vector_nearest_neighbor_base(conf.hash_num, table, schema, id) {
 
-  if (!(1 <= conf.hash_num)) {
-    throw JUBATUS_EXCEPTION(
-        common::invalid_parameter("1 <= hash_num"));
-  }
+  set_config(conf);
 }
 
 bit_vector minhash::hash(const common::sfv_t& sfv) const {
@@ -148,6 +142,14 @@ bit_vector minhash::hash(const common::sfv_t& sfv) const {
   }
 
   return bv;
+}
+
+void minhash::set_config(const config& conf) {
+  if (!(1 <= conf.hash_num)) {
+    throw JUBATUS_EXCEPTION(
+        common::invalid_parameter("1 <= hash_num"));
+  }
+  threads_ = read_threads_config(conf.threads);
 }
 
 }  // namespace nearest_neighbor

--- a/jubatus/core/nearest_neighbor/minhash.hpp
+++ b/jubatus/core/nearest_neighbor/minhash.hpp
@@ -22,6 +22,7 @@
 #include <string>
 #include <vector>
 #include "jubatus/util/data/serialization.h"
+#include "jubatus/util/data/optional.h"
 #include "jubatus/util/lang/shared_ptr.h"
 #include "bit_vector_nearest_neighbor_base.hpp"
 #include "../common/type.hpp"
@@ -39,14 +40,15 @@ class minhash : public bit_vector_nearest_neighbor_base {
  public:
   struct config {
     config()
-      : hash_num(64u) {
+      : hash_num(64u), threads() {
     }
 
     int32_t hash_num;
+    jubatus::util::data::optional<int32_t> threads;
 
     template <typename Ar>
     void serialize(Ar& ar) {
-      ar & JUBA_MEMBER(hash_num);
+      ar & JUBA_MEMBER(hash_num) & JUBA_MEMBER(threads);
     }
   };
 
@@ -66,6 +68,7 @@ class minhash : public bit_vector_nearest_neighbor_base {
 
  private:
   virtual storage::bit_vector hash(const common::sfv_t& sfv) const;
+  void set_config(const config& conf);
 };
 
 }  // namespace nearest_neighbor

--- a/jubatus/core/storage/abstract_column.hpp
+++ b/jubatus/core/storage/abstract_column.hpp
@@ -275,6 +275,9 @@ class typed_column<bit_vector> : public detail::abstract_column_base {
   bit_vector operator[](uint64_t index) const {
     return bit_vector(get_data_at_(index), type().bit_vector_length());
   }
+  const uint64_t* get_data_at_unsafe(size_t index) const {
+    return get_data_at_(index);
+  }
   bool remove(uint64_t target) {
     if (target >= size()) {
       return false;

--- a/jubatus/core/storage/bit_vector.cpp
+++ b/jubatus/core/storage/bit_vector.cpp
@@ -1,0 +1,120 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2016 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+#include "bit_vector.hpp"
+
+#ifdef JUBATUS_USE_FMV
+#include <nmmintrin.h>
+#endif
+
+namespace jubatus {
+namespace core {
+namespace storage {
+namespace detail {
+namespace {
+
+#ifdef JUBATUS_USE_FMV
+__attribute__((target("default")))
+#endif
+size_t calc_hamming_distance_impl(const uint64_t *x,
+                                  const uint64_t *y,
+                                  size_t blocks) {
+  size_t match_num = 0;
+  for (size_t i = 0; i < blocks; ++i) {
+    match_num += bitcount(x[i] ^ y[i]);
+  }
+  return match_num;
+}
+
+#ifdef JUBATUS_USE_FMV
+__attribute__((target("default")))
+#endif
+size_t bit_count_impl(const uint64_t *x, size_t blocks) {
+  size_t result = 0;
+  for (size_t i = 0; i < blocks; ++i) {
+    result += bitcount(x[i]);
+  }
+  return result;
+}
+
+#ifdef JUBATUS_USE_FMV
+__attribute__((target("popcnt")))
+size_t calc_hamming_distance_impl(const uint64_t *x,
+                                  const uint64_t *y,
+                                  size_t blocks) {
+  size_t match_num = 0;
+#ifdef __x86_64__
+  ssize_t i;
+  for (i = 0; i < static_cast<ssize_t>(blocks) - 3; i += 4) {
+    match_num += _mm_popcnt_u64(x[i] ^ y[i]);
+    match_num += _mm_popcnt_u64(x[i + 1] ^ y[i + 1]);
+    match_num += _mm_popcnt_u64(x[i + 2] ^ y[i + 2]);
+    match_num += _mm_popcnt_u64(x[i + 3] ^ y[i + 3]);
+  }
+  for (; i < blocks; ++i) {
+    match_num += _mm_popcnt_u64(x[i] ^ y[i]);
+  }
+#else  // #ifdef __x86_64__
+  const uint32_t *p0 = (const uint32_t*)x;
+  const uint32_t *p1 = (const uint32_t*)y;
+  blocks *= 2;
+  for (size_t i = 0; i < blocks; ++i) {
+    match_num += _mm_popcnt_u32(p0[i] ^ p1[i]);
+  }
+#endif  // #ifdef __x86_64__
+  return match_num;
+}
+
+__attribute__((target("popcnt")))
+size_t bit_count_impl(const uint64_t *x, size_t blocks) {
+  size_t result = 0;
+#ifdef __x86_64__
+  ssize_t i;
+  for (i = 0; i < static_cast<ssize_t>(blocks) - 3; i += 4) {
+    result += _mm_popcnt_u64(x[i]);
+    result += _mm_popcnt_u64(x[i + 1]);
+    result += _mm_popcnt_u64(x[i + 2]);
+    result += _mm_popcnt_u64(x[i + 3]);
+  }
+  for (; i < blocks; ++i) {
+    result += _mm_popcnt_u64(x[i]);
+  }
+#else  // #ifdef __x86_64__
+  const uint32_t *p = (const uint32_t*)x;
+  blocks *= 2;
+  for (size_t i = 0; i < blocks; ++i) {
+    result += _mm_popcnt_u32(p[i]);
+  }
+#endif  // #ifdef __x86_64__
+  return result;
+}
+#endif
+
+}  // namespace
+
+size_t calc_hamming_distance_internal(
+    const uint64_t *x, const uint64_t *y, size_t blocks) {
+  return calc_hamming_distance_impl(x, y, blocks);
+}
+
+size_t bit_count_internal(const uint64_t *x, size_t blocks) {
+  return bit_count_impl(x, blocks);
+}
+
+}  // namespace detail
+}  // namespace storage
+}  // namespace core
+}  // namespace jubatus

--- a/jubatus/core/storage/bit_vector.hpp
+++ b/jubatus/core/storage/bit_vector.hpp
@@ -318,23 +318,20 @@ struct bit_vector_base {
     } else if (bv.bits_ == NULL) {
       return bit_count();
     }
+    return calc_hamming_distance_unsafe(bv.bits_);
+  }
+  uint64_t calc_hamming_distance_unsafe(const bit_base *bv) const {
+    if (bits_ == NULL)
+      return bit_count_unsafe(bv, used_bytes());
     size_t match_num = 0;
     for (size_t i = 0, blocks = used_bytes() / sizeof(bit_base);
          i < blocks; ++i) {
-      match_num += detail::bitcount(bits_[i] ^ bv.bits_[i]);
+      match_num += detail::bitcount(bits_[i] ^ bv[i]);
     }
     return match_num;
   }
   size_t bit_count() const {
-    if (bits_ == NULL) {
-      return 0;
-    }
-    size_t result = 0;
-    for (size_t i = 0, blocks = used_bytes() / sizeof(bit_base);
-         i < blocks; ++i) {
-      result += detail::bitcount(bits_[i]);
-    }
-    return result;
+    return bit_count_unsafe(bits_, used_bytes());
   }
 
   bit_base* raw_data_unsafe() {
@@ -457,6 +454,18 @@ struct bit_vector_base {
       alloc_memory();
     }
     memcpy(bits_, orig.bits_, used_bytes());
+  }
+
+  static size_t bit_count_unsafe(const bit_base *bits, size_t bytes) {
+    if (bits == NULL) {
+      return 0;
+    }
+    size_t result = 0;
+    for (size_t i = 0, blocks = bytes / sizeof(bit_base);
+         i < blocks; ++i) {
+      result += detail::bitcount(bits[i]);
+    }
+    return result;
   }
 
   bit_base* bits_;

--- a/jubatus/core/storage/bit_vector.hpp
+++ b/jubatus/core/storage/bit_vector.hpp
@@ -74,29 +74,9 @@ struct bitcount_impl<T, 8> {
   }
 };
 
-#ifdef __POPCNT__
-
-inline int fast_bitcount(unsigned bits) {
-  return __builtin_popcount(bits);
-}
-
-inline int fast_bitcount(unsigned long bits) {  // NOLINT
-  return __builtin_popcountl(bits);
-}
-
-inline int fast_bitcount(unsigned long long bits) {  // NOLINT
-  return __builtin_popcountll(bits);
-}
-
-#endif
-
 template <class T>
 inline int bitcount_dispatcher(T bits) {
-#ifdef __POPCNT__
-  return fast_bitcount(bits);
-#else
   return bitcount_impl<T, sizeof(T)>::call(bits);
-#endif
 }
 
 inline int bitcount(unsigned bits) {
@@ -113,6 +93,10 @@ inline int bitcount(unsigned long long bits) {  // NOLINT
 
 template <class T>
 inline int bitcount(T);  // = delete;
+
+size_t calc_hamming_distance_internal(
+    const uint64_t *x, const uint64_t *y, size_t blocks);
+size_t bit_count_internal(const uint64_t *x, size_t blocks);
 
 }  // namespace detail
 
@@ -323,12 +307,8 @@ struct bit_vector_base {
   uint64_t calc_hamming_distance_unsafe(const bit_base *bv) const {
     if (bits_ == NULL)
       return bit_count_unsafe(bv, used_bytes());
-    size_t match_num = 0;
-    for (size_t i = 0, blocks = used_bytes() / sizeof(bit_base);
-         i < blocks; ++i) {
-      match_num += detail::bitcount(bits_[i] ^ bv[i]);
-    }
-    return match_num;
+    return detail::calc_hamming_distance_internal(
+        bits_, bv, used_bytes() / sizeof(bit_base));
   }
   size_t bit_count() const {
     return bit_count_unsafe(bits_, used_bytes());
@@ -460,12 +440,7 @@ struct bit_vector_base {
     if (bits == NULL) {
       return 0;
     }
-    size_t result = 0;
-    for (size_t i = 0, blocks = bytes / sizeof(bit_base);
-         i < blocks; ++i) {
-      result += detail::bitcount(bits[i]);
-    }
-    return result;
+    return detail::bit_count_internal(bits, bytes / sizeof(bit_base));
   }
 
   bit_base* bits_;

--- a/jubatus/core/storage/fixed_size_heap.hpp
+++ b/jubatus/core/storage/fixed_size_heap.hpp
@@ -28,6 +28,11 @@ namespace storage {
 template <typename T, typename Comp = std::less<T> >
 class fixed_size_heap {
  public:
+  fixed_size_heap()
+      : max_size_(0),
+        comp_(Comp()) {
+  }
+
   explicit fixed_size_heap(size_t max)
       : max_size_(max),
         comp_(Comp()) {
@@ -53,6 +58,11 @@ class fixed_size_heap {
     }
   }
 
+  void merge(const fixed_size_heap<T, Comp>& other) {
+    for (size_t i = 0; i < other.data_.size(); ++i)
+      push(other.data_[i]);
+  }
+
   void get_sorted(std::vector<T>& v) const {
     std::vector<T> vec(data_);
     std::sort(vec.begin(), vec.end(), comp_);
@@ -69,8 +79,8 @@ class fixed_size_heap {
 
  private:
   std::vector<T> data_;
-  const size_t max_size_;
-  const Comp comp_;
+  size_t max_size_;
+  Comp comp_;
 };
 
 }  // namespace storage

--- a/jubatus/core/storage/wscript
+++ b/jubatus/core/storage/wscript
@@ -29,7 +29,8 @@ def build(bld):
       'bit_index_storage.cpp',
       'lsh_vector.cpp',
       'lsh_util.cpp',
-      'lsh_index_storage.cpp'
+      'lsh_index_storage.cpp',
+      'bit_vector.cpp'
   ]
   headers = [
       'abstract_column.hpp',

--- a/jubatus/util/concurrent/thread.cpp
+++ b/jubatus/util/concurrent/thread.cpp
@@ -184,6 +184,15 @@ void* thread::impl::start_routine(void* p)
   return NULL;
 }
 
+unsigned thread::hardware_concurrency()
+{
+#ifdef __linux
+  return sysconf(_SC_NPROCESSORS_ONLN);
+#else
+  return 0;
+#endif
+}
+
 } // concurrent
 } // util
 } // jubatus

--- a/jubatus/util/concurrent/thread.h
+++ b/jubatus/util/concurrent/thread.h
@@ -51,6 +51,7 @@ public:
 
   static void yield();
   static bool sleep(double sec);
+  static unsigned hardware_concurrency();
 
   typedef int64_t tid_t;
   static tid_t id();


### PR DESCRIPTION
This pull request is based from non-merged branch.

based branch: #250 + #254
related issue: #244 

更新履歴
* 2016/03/23: 初版
* 2016/04/04: C++11の機能を使わずにマルチスレッド探索を実行できるようにしました

何点か議論するポイントがあります．
1. 各スレッドに割り当てる最低のデータサイズ(searchの場合は点の数，random_projectionの場合は特徴量の数)を定めるかどうか．定める場合コンフィグにすべきか定数にすべきか．(現在はデータサイズは気にせずにスレッド数で等分割しています)
2. searchとrandom_projectionの並列数は異なるコンフィグとすべきか (現在は同じコンフィグを共用しています)
3. スレッドプールの最大サイズを，threads にあわせるべきか (現在は実行した環境の論理コア数を上限としています)

また，今回 threads というオプションパラメータを追加しましたが，これはモデルに依存するパラメータというより，実行環境に依存するパラメータです．将来的にはこのパラメータはモデルに保存せずに，モデルロード時に指定するコンフィグで指定する値を利用するようにしたほうが良いと思っています．