### PR TITLE
Temporary disabled Ubuntu 16.04 tests in the TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,10 @@ matrix:
     - env:
       - DIST=ubuntu
       - VERSION=14.04
-    - env:
-      - DIST=ubuntu
-      - VERSION=16.04 # gcc 5.3 (enabled function multiversioning)
+# Bug: https://bugs.launchpad.net/ubuntu/+source/gcc-5/+bug/1568899
+#    - env:
+#      - DIST=ubuntu
+#      - VERSION=16.04 # gcc 5.3 (enabled function multiversioning)
 
 before_install:
   - docker pull ${DIST}:${VERSION}


### PR DESCRIPTION
#246 is affected by this ubuntu bug https://bugs.launchpad.net/ubuntu/+source/gcc-5/+bug/1568899