### PR TITLE
add include sys/types.h because of int64_t error on FreeBSD 10.3R

### DIFF
--- a/jubatus/util/concurrent/thread.h
+++ b/jubatus/util/concurrent/thread.h
@@ -35,6 +35,9 @@
 #include "../lang/function.h"
 #include "../lang/scoped_ptr.h"
 #include "../lang/noncopyable.h"
+#if defined(__FreeBSD__)
+#include <sys/types.h>
+#endif
 
 namespace jubatus {
 namespace util {

--- a/jubatus/util/concurrent/thread.h
+++ b/jubatus/util/concurrent/thread.h
@@ -32,12 +32,10 @@
 #ifndef JUBATUS_UTIL_CONCURRENT_THREAD_H_
 #define JUBATUS_UTIL_CONCURRENT_THREAD_H_
 
+#include <stdint.h>
 #include "../lang/function.h"
 #include "../lang/scoped_ptr.h"
 #include "../lang/noncopyable.h"
-#if defined(__FreeBSD__)
-#include <sys/types.h>
-#endif
 
 namespace jubatus {
 namespace util {


### PR DESCRIPTION
FreeBSD 10.3Rにgcc48をインストールしてビルドしてみたところint64_tのエラーがでていたので、sys/types.hをincludeしました。おそらくここに入れるのはあまり良くないような気もするので、適当なところ教えてもらえればそちらに移します。