### PR TITLE
Refactor fv_converter

### DIFF
--- a/jubatus/core/fv_converter/converter_config.cpp
+++ b/jubatus/core/fv_converter/converter_config.cpp
@@ -67,31 +67,8 @@ typedef jubatus::util::lang::shared_ptr<num_filter> num_filter_ptr;
 
 splitter_weight_type make_weight_type(
     const string& sample, const string& global) {
-  frequency_weight_type sample_type;
-  if (sample == "bin") {
-    sample_type = FREQ_BINARY;
-  } else if (sample == "tf") {
-    sample_type = TERM_FREQUENCY;
-  } else if (sample == "log_tf") {
-    sample_type = LOG_TERM_FREQUENCY;
-  } else {
-    throw JUBATUS_EXCEPTION(
-        converter_exception("unknown sample_weight: [" +
-                            sample + "] in string_rules"));
-  }
-
-  term_weight_type global_type;
-  if (global == "bin") {
-    global_type = TERM_BINARY;
-  } else if (global == "idf") {
-    global_type = IDF;
-  } else if (global == "weight") {
-    global_type = WITH_WEIGHT_FILE;
-  } else {
-    throw JUBATUS_EXCEPTION(
-        converter_exception("unknown global_weight: [" +
-                            global + "] in string_rules"));
-  }
+  frequency_weight_type sample_type = get_frequency_weight_type(sample);
+  term_weight_type global_type = get_term_weight_type(global);
   return splitter_weight_type(sample_type, global_type);
 }
 

--- a/jubatus/core/fv_converter/datum_to_fv_converter.cpp
+++ b/jubatus/core/fv_converter/datum_to_fv_converter.cpp
@@ -43,6 +43,16 @@ namespace jubatus {
 namespace core {
 namespace fv_converter {
 
+namespace {
+
+struct is_zero {
+  bool operator()(const std::pair<std::string, float>& p) {
+    return p.second == 0;
+  }
+};
+
+}  // namespace
+
 /// impl
 
 class datum_to_fv_converter_impl {
@@ -240,59 +250,74 @@ class datum_to_fv_converter_impl {
     }
   }
 
+  /**
+   * Converts the given Datum to Sparse Feature Vector.
+   * This is a `const` function that does not update weight_manager.
+   */
   void convert(const datum& datum, common::sfv_t& ret_fv) const {
     common::sfv_t fv;
-    convert_unweighted(datum, fv);
-    jubatus::util::lang::shared_ptr<weight_manager> weights =
-        mixable_weights_->get_model();
-    if (weights) {
-      weights->get_weight(fv);
-    }
 
-    convert_combinations(fv);
+    // Filter and convert string values (do not update weight).
+    std::vector<std::pair<std::string, std::string> >
+        string_records(datum.string_values_);
+    std::vector<std::pair<std::string, std::string> > filtered_string_records;
+    filter_strings(datum.string_values_, filtered_string_records);
+    string_records.insert(
+        string_records.end(),
+        filtered_string_records.begin(),
+        filtered_string_records.end());
+    convert_strings(string_records, fv);
 
-    if (hasher_) {
-      hasher_->hash_feature_keys(fv);
-    }
+    // Conversion process other than string values.
+    convert_common(datum, fv);
 
     fv.swap(ret_fv);
   }
 
+  /**
+   * Converts the given Datum to Sparse Feature Vector.
+   * This is a `non-const` function that updates weight_manager.
+   */
   void convert_and_update_weight(const datum& datum, common::sfv_t& ret_fv) {
     common::sfv_t fv;
-    convert_unweighted(datum, fv);
-    jubatus::util::lang::shared_ptr<weight_manager> weights =
-        mixable_weights_->get_model();
-    if (weights) {
-      weights->update_weight(fv);
-      weights->get_weight(fv);
-    }
 
-    convert_combinations(fv);
+    // Filter and convert string values (updates weight).
+    std::vector<std::pair<std::string, std::string> >
+        string_records(datum.string_values_);
+    std::vector<std::pair<std::string, std::string> > filtered_string_records;
+    filter_strings(datum.string_values_, filtered_string_records);
+    string_records.insert(
+        string_records.end(),
+        filtered_string_records.begin(),
+        filtered_string_records.end());
+    convert_strings_and_update_weight(string_records, fv);
 
-    if (hasher_) {
-      hasher_->hash_feature_keys(fv);
-    }
+    // Conversion process other than string values.
+    convert_common(datum, fv);
 
     fv.swap(ret_fv);
   }
 
-  void convert_unweighted(const datum& datum, common::sfv_t& ret_fv) const {
-    common::sfv_t fv;
-
-    std::vector<std::pair<std::string, std::string> > filtered_strings;
-    filter_strings(datum.string_values_, filtered_strings);
-    convert_strings(datum.string_values_, fv);
-    convert_strings(filtered_strings, fv);
-
+  void convert_common(const datum& datum, common::sfv_t& fv) const {
+    // Filter & Convert Numeric Values
     std::vector<std::pair<std::string, double> > filtered_nums;
     filter_nums(datum.num_values_, filtered_nums);
     convert_nums(datum.num_values_, fv);
     convert_nums(filtered_nums, fv);
 
+    // Convert Binary Values
     convert_binaries(datum.binary_values_, fv);
 
-    fv.swap(ret_fv);
+    // Remove dimension whose value is 0.
+    fv.erase(remove_if(fv.begin(), fv.end(), is_zero()), fv.end());
+
+    // Compute Combinations
+    convert_combinations(fv);
+
+    // Hash Feature Vector Keys
+    if (hasher_) {
+      hasher_->hash_feature_keys(fv);
+    }
   }
 
   void revert_feature(
@@ -373,8 +398,36 @@ class datum_to_fv_converter_impl {
   void convert_strings(
       const datum::sv_t& string_values,
       common::sfv_t& ret_fv) const {
+    jubatus::util::lang::shared_ptr<weight_manager> weights =
+        mixable_weights_->get_model();
+
     for (size_t i = 0; i < string_rules_.size(); ++i) {
-      convert_strings(string_rules_[i], string_values, ret_fv);
+      const string_feature_rule& splitter = string_rules_[i];
+
+      for (size_t j = 0; j < string_values.size(); ++j) {
+        const std::string& key = string_values[j].first;
+        const std::string& value = string_values[j].second;
+
+        if (!splitter.matcher_->match(key)) {
+          continue;
+        }
+
+        // Extract features from string (using splitter) and count its term
+        // frequency (TF).
+        counter<std::string> count;
+        count_words(splitter, value, count);
+
+        for (size_t k = 0; k < splitter.weights_.size(); ++k) {
+          // Extracted features are weighted by (sample_weight * global_weight)
+          // and added to the resulting feature vector (ret_fv).
+          weights->add_string_features(
+              key,
+              splitter.name_,
+              splitter.weights_[k],
+              count,
+              ret_fv);
+        }
+      }
     }
   }
 
@@ -387,18 +440,48 @@ class datum_to_fv_converter_impl {
     return false;
   }
 
-  void convert_strings(
-      const string_feature_rule& splitter,
+  void convert_strings_and_update_weight(
       const datum::sv_t& string_values,
-      common::sfv_t& ret_fv) const {
-    for (size_t j = 0; j < string_values.size(); ++j) {
-      const std::string& key = string_values[j].first;
-      const std::string& value = string_values[j].second;
-      counter<std::string> counter;
-      count_words(splitter, key, value, counter);
-      for (size_t i = 0; i < splitter.weights_.size(); ++i) {
-        make_string_features(
-            key, splitter.name_, splitter.weights_[i], counter, ret_fv);
+      common::sfv_t& ret_fv) {
+    jubatus::util::lang::shared_ptr<weight_manager> weights =
+        mixable_weights_->get_model();
+
+    // Increment document count (number of datum processed).
+    weights->increment_document_count();
+
+    for (size_t i = 0; i < string_rules_.size(); ++i) {
+      const string_feature_rule& splitter = string_rules_[i];
+
+      for (size_t j = 0; j < string_values.size(); ++j) {
+        const std::string& key = string_values[j].first;
+        const std::string& value = string_values[j].second;
+
+        if (!splitter.matcher_->match(key)) {
+          continue;
+        }
+
+        // Extract features from string (using splitter) and count its term
+        // frequency (TF).
+        counter<std::string> count;
+        count_words(splitter, value, count);
+
+        for (size_t k = 0; k < splitter.weights_.size(); ++k) {
+          // Update the weights.
+          weights->update_weight(
+              key,
+              splitter.name_,
+              splitter.weights_[k],
+              count);
+
+          // Extracted features are weighted by (sample_weight * global_weight)
+          // and added to the resulting feature vector (ret_fv).
+          weights->add_string_features(
+              key,
+              splitter.name_,
+              splitter.weights_[k],
+              count,
+              ret_fv);
+        }
       }
     }
   }
@@ -419,111 +502,27 @@ class datum_to_fv_converter_impl {
       const std::string& key = binary_values[j].first;
       const std::string& value = binary_values[j].second;
       if (feature.matcher_->match(key)) {
-        check_key(key);
-        feature.feature_func_->add_feature(key, value, ret_fv);
+        feature.feature_func_->add_feature(
+            make_binary_feature_name(key, feature.name_),
+            value,
+            ret_fv);
       }
     }
   }
 
-  static std::string make_feature(
-      const std::string& key,
-      const std::string& value,
-      const std::string& splitter,
-      const std::string& sample_weight,
-      const std::string& global_weight) {
-    check_key(key);
-    return key + "$" + value + "@" + splitter + "#" + sample_weight + "/" +
-        global_weight;
-  }
-
-  static std::string make_feature_key(
-      const std::string& key,
-      const std::string& value,
-      const std::string& splitter) {
-    check_key(key);
-    return key + "$" + value + "@" + splitter;
-  }
-
-  static void check_key(const std::string& key) {
-    if (key.find('$') != std::string::npos) {
-      throw JUBATUS_EXCEPTION(
-          converter_exception("feature key cannot contain '$': " + key));
-    }
-  }
-
+  /**
+   * Split the string `value` using the `splitter` feature extractor and
+   * compute the term frequency.
+   */
   void count_words(
       const string_feature_rule& splitter,
-      const std::string& key,
       const std::string& value,
       counter<std::string>& counter) const {
-    if (splitter.matcher_->match(key)) {
-      std::vector<string_feature_element> elements;
-      splitter.splitter_->extract(value, elements);
+    std::vector<string_feature_element> elements;
+    splitter.splitter_->extract(value, elements);
 
-      for (size_t i = 0; i < elements.size(); i++) {
-        counter[elements[i].value] += elements[i].score;
-      }
-    }
-  }
-
-  double get_sample_weight(
-      frequency_weight_type type,
-      double tf,
-      std::string& name) const {
-    switch (type) {
-      case FREQ_BINARY:
-        name = "bin";
-        return 1.0;
-
-      case TERM_FREQUENCY:
-        name = "tf";
-        return tf;
-
-      case LOG_TERM_FREQUENCY:
-        name = "log_tf";
-        return std::log(1. + tf);
-
-      default:
-        return 0;
-    }
-  }
-
-  std::string get_global_weight_name(term_weight_type type) const {
-    switch (type) {
-      case TERM_BINARY:
-        return "bin";
-      case IDF:
-        return "idf";
-      case WITH_WEIGHT_FILE:
-        return "weight";
-      default:
-        throw JUBATUS_EXCEPTION(
-          jubatus::core::common::exception::runtime_error(
-            "unknown global weight type"));
-    }
-  }
-
-  void make_string_features(
-      const std::string& key,
-      const std::string& splitter_name,
-      const splitter_weight_type& weight_type,
-      const counter<std::string>& count,
-      common::sfv_t& ret_fv) const {
-    for (counter<std::string>::const_iterator it = count.begin();
-         it != count.end(); ++it) {
-      std::string sample_weight_name;
-      double sample_weight = get_sample_weight(
-          weight_type.freq_weight_type_, it->second, sample_weight_name);
-
-      std::string global_weight_name = get_global_weight_name(
-          weight_type.term_weight_type_);
-      float v = static_cast<float>(sample_weight);
-      if (v != 0.0) {
-        std::string f = make_feature(
-            key, it->first, splitter_name, sample_weight_name,
-            global_weight_name);
-        ret_fv.push_back(std::make_pair(f, v));
-      }
+    for (size_t i = 0; i < elements.size(); i++) {
+      counter[elements[i].value] += elements[i].score;
     }
   }
 
@@ -542,9 +541,10 @@ class datum_to_fv_converter_impl {
     for (size_t i = 0; i < num_rules_.size(); ++i) {
       const num_feature_rule& r = num_rules_[i];
       if (r.matcher_->match(key)) {
-        check_key(key);
-        std::string k = key + "@" + r.name_;
-        r.feature_func_->add_feature(k, value, ret_fv);
+        r.feature_func_->add_feature(
+            make_num_feature_name(key, r.name_),
+            value,
+            ret_fv);
       }
     }
   }
@@ -687,6 +687,106 @@ void datum_to_fv_converter::set_weight_manager(
 
 void datum_to_fv_converter::clear_weights() {
   pimpl_->clear_weights();
+}
+
+frequency_weight_type get_frequency_weight_type(const std::string& name) {
+  if (name == "bin") {
+    return FREQ_BINARY;
+  } else if (name == "tf") {
+    return TERM_FREQUENCY;
+  } else if (name == "log_tf") {
+    return LOG_TERM_FREQUENCY;
+  } else {
+    throw JUBATUS_EXCEPTION(
+        converter_exception("unknown sample_weight: [" + name + "]"));
+  }
+}
+
+std::string get_frequency_weight_name(frequency_weight_type type) {
+  switch (type) {
+    case FREQ_BINARY:
+      return "bin";
+    case TERM_FREQUENCY:
+      return "tf";
+    case LOG_TERM_FREQUENCY:
+      return "log_tf";
+    default:  // this shouldn't happen
+      throw JUBATUS_EXCEPTION(converter_exception(
+          "unknown frequency_weight_type: [" +
+          lexical_cast<std::string>(type) + "]"));
+  }
+}
+
+term_weight_type get_term_weight_type(const std::string& name) {
+  if (name == "bin") {
+    return TERM_BINARY;
+  } else if (name == "idf") {
+    return IDF;
+  } else if (name == "weight") {
+    return WITH_WEIGHT_FILE;
+  } else {
+    throw JUBATUS_EXCEPTION(
+        converter_exception("unknown global_weight: [" + name + "]"));
+  }
+}
+
+std::string get_term_weight_name(term_weight_type type) {
+  switch (type) {
+    case TERM_BINARY:
+      return "bin";
+    case IDF:
+      return "idf";
+    case WITH_WEIGHT_FILE:
+      return "weight";
+    default:  // this shouldn't happen
+      throw JUBATUS_EXCEPTION(converter_exception(
+          "unknown term_weight_type: [" +
+          lexical_cast<std::string>(type) + "]"));
+  }
+}
+
+/**
+ * Checks if the datum key has a valid name.
+ */
+void check_key(const std::string& key) {
+  if (key.find('$') != std::string::npos) {
+    throw JUBATUS_EXCEPTION(
+        converter_exception("feature key cannot contain '$': " + key));
+  }
+}
+
+std::string make_string_feature_name(
+    const std::string& key,
+    const std::string& value,
+    const std::string& type,
+    frequency_weight_type sample_weight,
+    term_weight_type global_weight) {
+  check_key(key);
+  return key + "$" + value + "@" + type + "#" +
+         get_frequency_weight_name(sample_weight) + "/" +
+         get_term_weight_name(global_weight);
+}
+
+std::string make_num_feature_name(
+    const std::string& key,
+    const std::string& type) {
+  check_key(key);
+  return key + "@" + type;
+}
+
+std::string make_binary_feature_name(
+    const std::string& key,
+    const std::string& type) {
+  check_key(key);
+  return key;
+}
+
+std::string make_weight_name(
+    const std::string& key,
+    const std::string& value,
+    const std::string& type) {
+  check_key(key);
+  return key + "$" + value + "@" + type;
 }
 
 }  // namespace fv_converter

--- a/jubatus/core/fv_converter/datum_to_fv_converter.hpp
+++ b/jubatus/core/fv_converter/datum_to_fv_converter.hpp
@@ -23,25 +23,58 @@
 #include "jubatus/util/data/unordered_map.h"
 #include "jubatus/util/lang/shared_ptr.h"
 #include "jubatus/util/lang/scoped_ptr.h"
+#include "jubatus/util/lang/cast.h"
 #include "../common/type.hpp"
 #include "../framework/mixable.hpp"
+#include "exception.hpp"
+
+using jubatus::util::lang::lexical_cast;
 
 namespace jubatus {
 namespace core {
 namespace fv_converter {
 
+/**
+ * sample_weight
+ */
 enum frequency_weight_type {
   FREQ_BINARY,
   TERM_FREQUENCY,
   LOG_TERM_FREQUENCY
 };
 
+/**
+ * global_weight
+ */
 enum term_weight_type {
   TERM_BINARY,
   IDF,
   WITH_WEIGHT_FILE
 };
 
+/**
+ * Converts sample_weight name to enum.
+ */
+frequency_weight_type get_frequency_weight_type(const std::string& name);
+
+/**
+ * Converts sample_weight enum to name.
+ */
+std::string get_frequency_weight_name(frequency_weight_type type);
+
+/**
+ * Converts global_weight name to enum.
+ */
+term_weight_type get_term_weight_type(const std::string& name);
+
+/**
+ * Converts global_weight enum to name.
+ */
+std::string get_term_weight_name(term_weight_type type);
+
+/**
+ * A pair of sample_weight and global_weight configuration.
+ */
 struct splitter_weight_type {
   frequency_weight_type freq_weight_type_;
   term_weight_type term_weight_type_;
@@ -53,6 +86,38 @@ struct splitter_weight_type {
         term_weight_type_(term_weight_type) {
   }
 };
+
+/**
+ * Creates a key name of Sparse Feature Vector for string features.
+ */
+std::string make_string_feature_name(
+    const std::string& key,
+    const std::string& value,
+    const std::string& type,
+    frequency_weight_type sample_weight,
+    term_weight_type global_weight);
+
+/**
+ * Creates a key name of Sparse Feature Vector for numeric features.
+ */
+std::string make_num_feature_name(
+    const std::string& key,
+    const std::string& type);
+
+/**
+ * Creates a key name of Sparse Feature Vector for binary features.
+ */
+std::string make_binary_feature_name(
+    const std::string& key,
+    const std::string& type);
+
+/**
+ * Creates a key name of user defined weight.
+ */
+std::string make_weight_name(
+    const std::string& key,
+    const std::string& value,
+    const std::string& type);
 
 struct datum;
 class datum_to_fv_converter_impl;

--- a/jubatus/core/fv_converter/keyword_weights.cpp
+++ b/jubatus/core/fv_converter/keyword_weights.cpp
@@ -19,6 +19,8 @@
 #include <string>
 #include <sstream>
 #include <utility>
+#include <vector>
+
 #include "jubatus/util/lang/cast.h"
 #include "../common/type.hpp"
 #include "datum_to_fv_converter.hpp"
@@ -49,10 +51,15 @@ keyword_weights::keyword_weights()
       weights_() {
 }
 
-void keyword_weights::update_document_frequency(const sfv_t& fv) {
+void keyword_weights::increment_document_count() {
   ++document_count_;
-  for (sfv_t::const_iterator it = fv.begin(); it != fv.end(); ++it) {
-    ++document_frequencies_[it->first];
+}
+
+void keyword_weights::increment_document_frequency(
+    const std::vector<std::string> keys) {
+  for (std::vector<std::string>::const_iterator it = keys.begin();
+       it != keys.end(); ++it) {
+    ++document_frequencies_[*it];
   }
 }
 

--- a/jubatus/core/fv_converter/keyword_weights.hpp
+++ b/jubatus/core/fv_converter/keyword_weights.hpp
@@ -19,6 +19,7 @@
 
 #include <map>
 #include <string>
+#include <vector>
 #include <msgpack.hpp>
 #include "jubatus/util/data/unordered_map.h"
 #include "../common/type.hpp"
@@ -32,7 +33,8 @@ class keyword_weights {
  public:
   keyword_weights();
 
-  void update_document_frequency(const common::sfv_t& fv);
+  void increment_document_count();
+  void increment_document_frequency(const std::vector<std::string> keys);
 
   size_t get_document_frequency(const std::string& key) const {
     return document_frequencies_[key];

--- a/jubatus/core/fv_converter/keyword_weights_test.cpp
+++ b/jubatus/core/fv_converter/keyword_weights_test.cpp
@@ -16,6 +16,9 @@
 
 #include <cmath>
 #include <utility>
+#include <string>
+#include <vector>
+
 #include <gtest/gtest.h>
 #include "../common/type.hpp"
 #include "keyword_weights.hpp"
@@ -27,13 +30,14 @@ namespace fv_converter {
 TEST(keyword_weights, trivial) {
   keyword_weights m, m2;
   {
-    common::sfv_t fv;
+    std::vector<std::string> keys;
 
-    m.update_document_frequency(fv);
+    m.increment_document_count();
 
-    fv.push_back(std::make_pair("key1", 1.0));
-    fv.push_back(std::make_pair("key2", 1.0));
-    m.update_document_frequency(fv);
+    keys.push_back("key1");
+    keys.push_back("key2");
+    m.increment_document_count();
+    m.increment_document_frequency(keys);
 
     m.add_weight("key3", 2.0);
 
@@ -43,12 +47,13 @@ TEST(keyword_weights, trivial) {
   }
 
   {
-    common::sfv_t fv;
-    m2.update_document_frequency(fv);
+    std::vector<std::string> keys;
+    m2.increment_document_count();
 
-    fv.push_back(std::make_pair("key1", 1.0));
-    fv.push_back(std::make_pair("key2", 1.0));
-    m2.update_document_frequency(fv);
+    keys.push_back("key1");
+    keys.push_back("key2");
+    m2.increment_document_count();
+    m2.increment_document_frequency(keys);
 
     m2.add_weight("key3", 3.0);
 

--- a/jubatus/core/fv_converter/weight_manager.hpp
+++ b/jubatus/core/fv_converter/weight_manager.hpp
@@ -30,6 +30,7 @@
 #include "../common/type.hpp"
 #include "../common/version.hpp"
 #include "keyword_weights.hpp"
+#include "datum_to_fv_converter.hpp"
 
 namespace jubatus {
 namespace core {
@@ -52,8 +53,18 @@ class weight_manager : public framework::model {
  public:
   weight_manager();
 
-  void update_weight(const common::sfv_t& fv);
-  void get_weight(common::sfv_t& fv) const;
+  void increment_document_count();
+  void update_weight(
+      const std::string& key,
+      const std::string& type_name,
+      const splitter_weight_type& weight_type,
+      const counter<std::string>& count);
+  void add_string_features(
+      const std::string& key,
+      const std::string& type_name,
+      const splitter_weight_type& weight_type,
+      const counter<std::string>& count,
+      common::sfv_t& ret_fv) const;
 
   void add_weight(const std::string& key, float weight);
 
@@ -133,7 +144,14 @@ class weight_manager : public framework::model {
         master_weights_.get_user_weight(key);
   }
 
-  double get_global_weight(const std::string& key) const;
+  double get_sample_weight(
+      frequency_weight_type type,
+      double tf) const;
+
+  double get_global_weight(
+      term_weight_type type,
+      const std::string& fv_name,
+      const std::string& weight_name) const;
 
   mutable util::concurrent::mutex mutex_;
   storage::version version_;


### PR DESCRIPTION
We are going to implement BM25 weighting (#284).  However, current fv_converter design only expects TF-IDF, which is hard to introduce another weighting algorithm.  To resolve this I refactored fv_converter.

Key points of this change:

* The external interface of fv_converter (`datum_to_fv_converter` class) is not changed.  No need to modify existing engines using fv_converter.
* Interface between `datum_to_fv_converter`, `weight_manager`, `keyword_weights` is modified.
* No changes to MIX protocol and data structure (model file format).
* Weighting for string features are now performed for each rule.  Prior to this fix, weighting is performed after all feature extractions are done.  This may affect users who defines the same `string_rule` multiple times, which we assume almost no one does.
* Weighing is now performed only for string features.  Prior to this fix, `weight_manager` records frequencies of all sfv_t (Sparse Feature Vector), including ones extracted from num_values and binary_values.  As frequencies of num/binary vectors will never be used (because they don't have any weighting system like TF-IDF), this does not break the existing behavior.  Users may observe slightly smaller file size when they saved the model file.