### PR TITLE
improve NN euclid_lsh calculation accuracy when hamming distance is zero (fix #253)

### DIFF
--- a/jubatus/core/nearest_neighbor/euclid_lsh.cpp
+++ b/jubatus/core/nearest_neighbor/euclid_lsh.cpp
@@ -148,9 +148,15 @@ static heap_t ranking_hamming_bit_vectors_worker(
   for (size_t i = off; i < end; ++i) {
     const size_t hamm_dist =
       bv->calc_hamming_distance_unsafe(bv_col->get_data_at_unsafe(i));
-    const float theta = hamm_dist * M_PI / denom;
-    const float score =
-      (*norm_col)[i] * ((*norm_col)[i] - 2 * norm * std::cos(theta));
+    const float norm_i = (*norm_col)[i];
+    float score;
+    if (hamm_dist == 0) {
+      score = std::fabs(norm - norm_i);
+    } else {
+      const float theta = hamm_dist * M_PI / denom;
+      score = std::sqrt(
+          norm * norm + norm_i * norm_i - 2 * norm * norm_i * std::cos(theta));
+    }
     heap.push(make_pair(score, i));
   }
   return heap;
@@ -178,10 +184,8 @@ void euclid_lsh::neighbor_row_from_hash(
   heap.get_sorted(sorted);
 
   ids.clear();
-  const float squared_norm = norm * norm;
   for (size_t i = 0; i < sorted.size(); ++i) {
-    ids.push_back(make_pair(table->get_key(sorted[i].second),
-                            std::sqrt(squared_norm + sorted[i].first)));
+    ids.push_back(make_pair(table->get_key(sorted[i].second), sorted[i].first));
   }
 }
 


### PR DESCRIPTION
This fixes #253: distance between two points that are very close to each other cannot be calculated properly in some cases.

In this PR, I fixed the code to directly calculate the distance between two points if the hamming distance, which is a result of Cosine LSH, is 0 (i.e., cosine similarity of two points are 1.0).
This is a technique already used in Euclid LSH of Recommender.  https://github.com/jubatus/jubatus_core/blob/0.3.0/jubatus/core/storage/lsh_index_storage.cpp#L98