### PR TITLE
Improve Recommender inverted_index/inverted_index_euclid calculation accuracy between same data points

### DIFF
--- a/jubatus/core/storage/inverted_index_storage.cpp
+++ b/jubatus/core/storage/inverted_index_storage.cpp
@@ -389,11 +389,11 @@ void inverted_index_storage::calc_euclid_scores(
   storage::fixed_size_heap<pair<float, uint64_t>,
                            std::greater<pair<float, uint64_t> > > heap(ret_num);
 
-  float query_norm = calc_l2norm(query);
+  float squared_query_norm = calc_squared_l2norm(query);
   for (size_t i = 0; i < i_scores.size(); ++i) {
-    float norm = calc_columnl2norm(i);
+    float squared_norm = calc_column_squared_l2norm(i);
 
-    if (norm == 0.f) {
+    if (squared_norm == 0.f) {
       // The column is already removed.
       continue;
     }
@@ -403,8 +403,8 @@ void inverted_index_storage::calc_euclid_scores(
     // expected to be 0) due to the floating point precision problem.
     // This cause `sqrt(d2)` to return NaN, which is not what we want.
     // To avoid this we use `sqrt(max(0, d2))`.
-    float d2 = query_norm * query_norm + norm * norm - 2 * i_scores[i];
-    heap.push(make_pair(-std::sqrt(std::max(0.0f, d2)), i));
+    float d2 = squared_query_norm + squared_norm - 2 * i_scores[i];
+    heap.push(make_pair(-std::sqrt(std::max(0.f, d2)), i));
   }
 
   vector<pair<float, uint64_t> > sorted_scores;

--- a/jubatus/core/storage/inverted_index_storage.hpp
+++ b/jubatus/core/storage/inverted_index_storage.hpp
@@ -91,7 +91,9 @@ class inverted_index_storage {
 
  private:
   static float calc_l2norm(const common::sfv_t& sfv);
+  static float calc_squared_l2norm(const common::sfv_t& sfv);
   float calc_columnl2norm(uint64_t column_id) const;
+  float calc_column_squared_l2norm(uint64_t column_id) const;
   float get_from_tbl(
       const std::string& row,
       uint64_t column_id,


### PR DESCRIPTION
This fixes #251: distance between two same points cannot be calculated properly in some cases.

In this PR, I eliminated the redundant calculation, e.g., replacing `sqrt(x) * sqrt(x)` with `x`, to avoid unnecessary dropping float precision.