### PR TITLE
add include guard check to run_cpplit (core)

### DIFF
--- a/tools/codestyle/run_cpplint.sh
+++ b/tools/codestyle/run_cpplint.sh
@@ -11,3 +11,5 @@ find ${@} '(' \
     ')' \
 | xargs "$(dirname ${0})/cpplint/cpplint.py" --filter=-runtime/references,-runtime/rtti 2>&1 \
 | grep -v '^Done processing '
+
+"$(dirname ${0})/check_include_guard.sh" $(find ${@} -name "*.hpp")


### PR DESCRIPTION
Now `./waf cpplint` checks include guard.

Refs https://github.com/jubatus/jubatus/pull/1119