### PR TITLE
Fix deadlock in NN-Classifier

### DIFF
--- a/jubatus/core/storage/column_table.hpp
+++ b/jubatus/core/storage/column_table.hpp
@@ -355,6 +355,10 @@ class column_table {
 
   bool delete_row(const std::string& target) {
     jubatus::util::concurrent::scoped_wlock lk(table_lock_);
+    return delete_row_nolock(target);
+  }
+
+  bool delete_row_nolock(const std::string& target) {
     index_table::const_iterator it = index_.find(target);
     if (it == index_.end()) {
       return false;
@@ -365,6 +369,10 @@ class column_table {
 
   bool delete_row(uint64_t index) {
     jubatus::util::concurrent::scoped_wlock lk(table_lock_);
+    return delete_row(index);
+  }
+
+  bool delete_row_nolock(uint64_t index) {
     if (size() <= index) {
       return false;
     }

--- a/jubatus/core/storage/column_table.hpp
+++ b/jubatus/core/storage/column_table.hpp
@@ -369,7 +369,7 @@ class column_table {
 
   bool delete_row(uint64_t index) {
     jubatus::util::concurrent::scoped_wlock lk(table_lock_);
-    return delete_row(index);
+    return delete_row_nolock(index);
   }
 
   bool delete_row_nolock(uint64_t index) {


### PR DESCRIPTION
I found the code that may cause deadlock in `nearest_neighbor_classifier`.


* ``train`` using ``unlearner``
  * ``touch`` is called in ``column_table::set_row`` (called from ``push`` RPC). In ``set_row``, ``column_table`` acquire the lock. So, ``touch`` must not get the lock.
* ``regenerate_labels``
  * ``scoped_rlock`` is acquired in ``regenerate_labels``. But ``get_key_nolock`` and ``size_nolock`` are not used in this scope.

In addition, I reconsider the exclusive control in ``delete_label``.

* Calling ``table->get_key()`` many times is very heavy operation. So, I changed the way of exclusive control.