### PR TITLE
disable _GLIBCXX_DEBUG when configured with --enable-debug

### DIFF
--- a/wscript
+++ b/wscript
@@ -63,9 +63,20 @@ def configure(conf):
   conf.check_cxx(lib = 'msgpack')
 
   if Options.options.debug:
-    conf.define('_GLIBCXX_DEBUG', 1)
+    """
+    You can compile "debug-enabled" version of Jubatus Core by ``./waf configure --enable-debug ...``.
+    In debug-enabled Jubatus Core, assertions are enabled.
+
+    In addition, if you want to enable Glibc C++ debugging feature (useful to debug STL-related
+    issues), you can uncomment the following line.  Note that dependency libraries (log4cxx) must
+    must be recompiled with this option.
+    """
+    # conf.define('_GLIBCXX_DEBUG', 1)
   else:
+    # Disable standard assertions
     conf.define('NDEBUG', 1)
+
+    # Disable Jubatus specific assertions
     conf.define('JUBATUS_DISABLE_ASSERTIONS', 1)
 
   if Options.options.gcov:


### PR DESCRIPTION
This fix was needed in jubatus_core too. https://github.com/jubatus/jubatus/pull/1136, https://github.com/jubatus/jubatus/issues/910