### PR TITLE
Feature/ignore orthogonal vectors

### DIFF
--- a/jubatus/core/recommender/inverted_index_euclid.hpp
+++ b/jubatus/core/recommender/inverted_index_euclid.hpp
@@ -21,6 +21,9 @@
 #include <utility>
 #include <vector>
 #include "inverted_index.hpp"
+#include "jubatus/util/data/optional.h"
+#include "jubatus/util/data/serialization.h"
+#include "../common/jsonconfig.hpp"
 
 namespace jubatus {
 namespace core {
@@ -28,10 +31,24 @@ namespace recommender {
 
 class inverted_index_euclid : public inverted_index {
  public:
+  struct config {
+    jubatus::util::data::optional<bool> ignore_orthogonal;
+    jubatus::util::data::optional<std::string> unlearner;
+    jubatus::util::data::optional<core::common::jsonconfig::config>
+        unlearner_parameter;
+
+    template<typename Ar>
+    void serialize(Ar& ar) {
+      ar
+        & JUBA_MEMBER(ignore_orthogonal)
+        & JUBA_MEMBER(unlearner)
+        & JUBA_MEMBER(unlearner_parameter);
+    }
+  };
+
   inverted_index_euclid();
   ~inverted_index_euclid();
-  explicit inverted_index_euclid(
-      jubatus::util::lang::shared_ptr<unlearner::unlearner_base> unlearner);
+  explicit inverted_index_euclid(const config& config);
 
   void similar_row(
       const common::sfv_t& query,
@@ -43,6 +60,9 @@ class inverted_index_euclid : public inverted_index {
       size_t ret_num) const;
 
   std::string type() const;
+
+ private:
+  bool ignore_orthogonal_;
 };
 
 }  // namespace recommender

--- a/jubatus/core/recommender/inverted_index_euclid_test.cpp
+++ b/jubatus/core/recommender/inverted_index_euclid_test.cpp
@@ -1,0 +1,142 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2016 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+#include <string>
+#include <vector>
+#include <utility>
+#include <gtest/gtest.h>
+#include "jubatus/util/lang/shared_ptr.h"
+
+#include "inverted_index_euclid.hpp"
+#include "../common/jsonconfig.hpp"
+#include "../common/type.hpp"
+
+using jubatus::util::text::json::json;
+using jubatus::util::text::json::json_object;
+using jubatus::util::text::json::to_json;
+using jubatus::core::common::jsonconfig::config_cast;
+using jubatus::core::common::sfv_t;
+
+namespace jubatus {
+namespace core {
+namespace recommender {
+
+TEST(inverted_index_euclid, config_validation_with_unlearner) {
+  jubatus::util::lang::shared_ptr<inverted_index_euclid> r;
+
+  {
+    json js(new json_object);
+    js["unlearner"] = to_json(std::string("lru"));
+    js["unlearner_parameter"] = new json_object;
+    js["unlearner_parameter"]["max_size"] = to_json(1);
+    common::jsonconfig::config conf(js);
+    ASSERT_NO_THROW(r.reset(new inverted_index_euclid(
+        config_cast<inverted_index_euclid::config>(conf))));
+  }
+
+  {
+    json js(new json_object);
+    js["unlearner"] = to_json(std::string("lru"));
+    common::jsonconfig::config conf(js);
+    ASSERT_THROW(
+      r.reset(new inverted_index_euclid(
+          config_cast<inverted_index_euclid::config>(conf))),
+      common::config_exception);
+  }
+}
+
+TEST(inverted_index_euclid, config_validation_ignore_orthogonal) {
+  jubatus::util::lang::shared_ptr<inverted_index_euclid> r;
+
+  {
+    json js(new json_object);
+    {
+      common::jsonconfig::config conf(js);
+      ASSERT_NO_THROW(r.reset(new inverted_index_euclid(
+          config_cast<inverted_index_euclid::config>(conf))));
+    }
+    {
+      js["ignore_orthogonal"] = to_json(true);
+      common::jsonconfig::config conf(js);
+      ASSERT_NO_THROW(r.reset(new inverted_index_euclid(
+          config_cast<inverted_index_euclid::config>(conf))));
+    }
+    {
+      js["ignore_orthogonal"] = to_json(false);
+      common::jsonconfig::config conf(js);
+      ASSERT_NO_THROW(r.reset(new inverted_index_euclid(
+          config_cast<inverted_index_euclid::config>(conf))));
+    }
+  }
+}
+
+TEST(inverted_index_euclid, trivial_test) {
+  jubatus::util::lang::shared_ptr<inverted_index_euclid> r;
+  json js(new json_object);
+  common::jsonconfig::config conf(js);
+  r.reset(new inverted_index_euclid(
+      config_cast<inverted_index_euclid::config>(conf)));
+  sfv_t v1, v2;
+  std::vector<std::pair<std::string, float> > res;
+  v1.push_back(std::pair<std::string, float>("a", 1.0));
+  v1.push_back(std::pair<std::string, float>("b", 1.0));
+  v2.push_back(std::pair<std::string, float>("a", 4.0));
+  v2.push_back(std::pair<std::string, float>("b", 5.0));
+  r->update_row("v1", v1);
+  r->update_row("v2", v2);
+  r->similar_row(v1, res, 2);
+  EXPECT_EQ(res[0].first, "v1");
+  EXPECT_EQ(res[0].second, 0);
+  EXPECT_EQ(res[1].second, -5.0);
+}
+
+TEST(inverted_index_euclid, trivial_test_with_ignore_orthogonal) {
+  jubatus::util::lang::shared_ptr<inverted_index_euclid> r;
+  json js(new json_object);
+  js["ignore_orthogonal"] = to_json(true);
+  common::jsonconfig::config conf(js);
+  r.reset(new inverted_index_euclid(
+      config_cast<inverted_index_euclid::config>(conf)));
+  sfv_t v1, v2, q1, q2;
+
+  std::vector<std::pair<std::string, float> > res;
+  v1.push_back(std::pair<std::string, float>("a", 1.0));
+  v1.push_back(std::pair<std::string, float>("b", 1.0));
+  v2.push_back(std::pair<std::string, float>("a", 4.0));
+  v2.push_back(std::pair<std::string, float>("c", 5.0));
+
+  r->update_row("v1", v1);
+  r->update_row("v2", v2);
+
+  q1.push_back(std::pair<std::string, float>("a", 1.0));
+
+  r->similar_row(q1, res, 2);
+
+  EXPECT_EQ(res[0].first, "v1");
+  EXPECT_EQ(res[0].second, -1.0);
+  EXPECT_EQ(res[1].first, "v2");
+  EXPECT_FLOAT_EQ(res[1].second, -5.83095);
+  q2.push_back(std::pair<std::string, float>("c", 1.0));
+  res.clear();
+  r->similar_row(q2, res, 2);
+  EXPECT_EQ(res.size(), 1u);
+  EXPECT_EQ(res[0].first, "v2");
+  EXPECT_FLOAT_EQ(res[0].second, -5.6568542);
+}
+
+}  // namespace recommender
+}  // namespace core
+}  // namespace jubatus

--- a/jubatus/core/recommender/inverted_index_euclid_test.cpp
+++ b/jubatus/core/recommender/inverted_index_euclid_test.cpp
@@ -110,7 +110,7 @@ TEST(inverted_index_euclid, trivial_test_with_ignore_orthogonal) {
   common::jsonconfig::config conf(js);
   r.reset(new inverted_index_euclid(
       config_cast<inverted_index_euclid::config>(conf)));
-  sfv_t v1, v2, q1, q2;
+  sfv_t v1, v2, q1, q2, q3;
 
   std::vector<std::pair<std::string, float> > res;
   v1.push_back(std::pair<std::string, float>("a", 1.0));
@@ -129,12 +129,21 @@ TEST(inverted_index_euclid, trivial_test_with_ignore_orthogonal) {
   EXPECT_EQ(res[0].second, -1.0);
   EXPECT_EQ(res[1].first, "v2");
   EXPECT_FLOAT_EQ(res[1].second, -5.83095);
+
   q2.push_back(std::pair<std::string, float>("c", 1.0));
   res.clear();
   r->similar_row(q2, res, 2);
   EXPECT_EQ(res.size(), 1u);
   EXPECT_EQ(res[0].first, "v2");
   EXPECT_FLOAT_EQ(res[0].second, -5.6568542);
+
+  q3.push_back(std::pair<std::string, float>("a", 1.0));
+  q3.push_back(std::pair<std::string, float>("b", -1.0));
+  res.clear();
+  r->similar_row(q3, res, 2);
+  EXPECT_EQ(res.size(), 2u);
+  EXPECT_EQ(res[0].first, "v1");
+  EXPECT_FLOAT_EQ(res[0].second, -2.0);
 }
 
 }  // namespace recommender

--- a/jubatus/core/recommender/recommender_factory.cpp
+++ b/jubatus/core/recommender/recommender_factory.cpp
@@ -92,27 +92,12 @@ shared_ptr<recommender_base> recommender_factory::create_recommender(
     return shared_ptr<recommender_base>(new inverted_index);
   } else if (name == "inverted_index_euclid") {
     if (!param.is_null()) {
-      inverted_index_config conf =
-          config_cast_check<inverted_index_config>(param);
-      if (conf.unlearner) {
-        if (!conf.unlearner_parameter) {
-          throw JUBATUS_EXCEPTION(
-              common::config_exception() << common::exception::error_message(
-                  "unlearner is set but unlearner_parameter is not found"));
-        }
-        return shared_ptr<recommender_base>(
-            new inverted_index_euclid(unlearner::create_unlearner(
-                *conf.unlearner, common::jsonconfig::config(
-                    *conf.unlearner_parameter))));
-      } else {
-        if (conf.unlearner_parameter) {
-          throw JUBATUS_EXCEPTION(
-              common::config_exception() << common::exception::error_message(
-                  "unlearner_parameter is set but unlearner is not found"));
-        }
-      }
+      return shared_ptr<recommender_base>(
+          new inverted_index_euclid(
+            config_cast_check<inverted_index_euclid::config>(param)));
+    } else {
+      return shared_ptr<recommender_base>(new inverted_index_euclid);
     }
-    return shared_ptr<recommender_base>(new inverted_index_euclid);
   } else if (name == "minhash") {
     return shared_ptr<recommender_base>(
         new minhash(config_cast_check<minhash::config>(param)));

--- a/jubatus/core/recommender/recommender_factory_test.cpp
+++ b/jubatus/core/recommender/recommender_factory_test.cpp
@@ -82,6 +82,24 @@ std::vector<recommender_parameter> generate_parameters() {
     }
   }
 
+  {  // inverted index euclid
+    json js(new json_object);
+    ret.push_back(
+        recommender_parameter(
+          "inverted_index_euclid",
+          common::jsonconfig::config(js)));
+    {  // unlearn
+      json js_unlearn(js.clone());
+      js_unlearn["unlearner"] = to_json(std::string("lru"));
+      js_unlearn["unlearner_parameter"] = new json_object;
+      js_unlearn["unlearner_parameter"]["max_size"] = to_json(1);
+      ret.push_back(
+          recommender_parameter(
+              "inverted_index_euclid",
+              common::jsonconfig::config(js_unlearn)));
+    }
+  }
+
   {  // minhash / lsh
     json js(new json_object);
     json js_unlearn(js.clone());

--- a/jubatus/core/recommender/wscript
+++ b/jubatus/core/recommender/wscript
@@ -45,4 +45,5 @@ def build(bld):
       'minhash_test.cpp',
       'lsh_test.cpp',
       'recommender_factory_test.cpp',
+      'inverted_index_euclid_test.cpp'
       ])

--- a/jubatus/core/storage/inverted_index_storage.cpp
+++ b/jubatus/core/storage/inverted_index_storage.cpp
@@ -439,12 +439,6 @@ void inverted_index_storage::calc_euclid_scores_ignore_orthogonal(
   for (unordered_set<int>::const_iterator it = i_scores_index_set.begin(); 
        it != i_scores_index_set.end(); 
        ++it) {
-    float score = i_scores[*(it)];
-    if (score == 0.f) {
-      // ignore vectors if dot product is zero
-      continue;
-    }
-
     float squared_norm = calc_column_squared_l2norm(*(it));
 
     if (squared_norm == 0.f) {

--- a/jubatus/core/storage/inverted_index_storage.cpp
+++ b/jubatus/core/storage/inverted_index_storage.cpp
@@ -436,8 +436,8 @@ void inverted_index_storage::calc_euclid_scores_ignore_orthogonal(
 
   float squared_query_norm = calc_squared_l2norm(query);
 
-  for (unordered_set<int>::const_iterator it = i_scores_index_set.begin(); 
-       it != i_scores_index_set.end(); 
+  for (unordered_set<int>::const_iterator it = i_scores_index_set.begin();
+       it != i_scores_index_set.end();
        ++it) {
     float squared_norm = calc_column_squared_l2norm(*(it));
 
@@ -460,8 +460,8 @@ void inverted_index_storage::calc_euclid_scores_ignore_orthogonal(
 
   for (size_t i = 0; i < sorted_scores.size() && i < ret_num; ++i) {
     scores.push_back(
-		     make_pair(column2id_.get_key(sorted_scores[i].second),
-			       sorted_scores[i].first));
+        make_pair(column2id_.get_key(sorted_scores[i].second),
+        sorted_scores[i].first));
   }
 }
 
@@ -538,7 +538,7 @@ void inverted_index_storage::add_inp_scores(
   if (it_diff != inv_diff_.end()) {
     const row_t& row_v = it_diff->second;
     for (row_t::const_iterator row_it = row_v.begin(); row_it != row_v.end();
-	 ++row_it) {
+         ++row_it) {
       scores[row_it->first] += row_it->second * val;
       // records the row index when dot product is calculated
       scores_index_set.insert(row_it->first);
@@ -550,18 +550,18 @@ void inverted_index_storage::add_inp_scores(
     const row_t& row_v = it->second;
     if (it_diff == inv_diff_.end()) {
       for (row_t::const_iterator row_it = row_v.begin(); row_it != row_v.end();
-	   ++row_it) {
+           ++row_it) {
         scores[row_it->first] += row_it->second * val;
-	// records the row index when dot product is calculated
-	scores_index_set.insert(row_it->first);
+        // records the row index when dot product is calculated
+        scores_index_set.insert(row_it->first);
       }
     } else {
       const row_t& row_diff_v = it_diff->second;
       for (row_t::const_iterator row_it = row_v.begin(); row_it != row_v.end();
-	   ++row_it) {
+           ++row_it) {
         if (row_diff_v.find(row_it->first) == row_diff_v.end()) {
           scores[row_it->first] += row_it->second * val;
-	  scores_index_set.insert(row_it->first);
+          scores_index_set.insert(row_it->first);
         }
       }
     }

--- a/jubatus/core/storage/inverted_index_storage.cpp
+++ b/jubatus/core/storage/inverted_index_storage.cpp
@@ -25,6 +25,7 @@
 
 #include "../storage/fixed_size_heap.hpp"
 #include "jubatus/util/data/unordered_map.h"
+#include "jubatus/util/data/unordered_set.h"
 
 using std::istringstream;
 using std::make_pair;
@@ -35,6 +36,7 @@ using std::sqrt;
 using std::string;
 using std::vector;
 using jubatus::util::data::unordered_map;
+using jubatus::util::data::unordered_set;
 
 namespace jubatus {
 namespace core {
@@ -417,6 +419,59 @@ void inverted_index_storage::calc_euclid_scores(
   }
 }
 
+void inverted_index_storage::calc_euclid_scores_ignore_orthogonal(
+    const common::sfv_t& query,
+    vector<pair<string, float> >& scores,
+    size_t ret_num) const {
+  std::vector<float> i_scores(column2id_.get_max_id() + 1, 0.0);
+  unordered_set<int> i_scores_index_set;
+  for (size_t i = 0; i < query.size(); ++i) {
+    const string& fid = query[i].first;
+    float val = query[i].second;
+    add_inp_scores(fid, val, i_scores, i_scores_index_set);
+  }
+
+  storage::fixed_size_heap<pair<float, uint64_t>,
+                           std::greater<pair<float, uint64_t> > > heap(ret_num);
+
+  float squared_query_norm = calc_squared_l2norm(query);
+
+  for (unordered_set<int>::const_iterator it = i_scores_index_set.begin(); 
+       it != i_scores_index_set.end(); 
+       ++it) {
+    float score = i_scores[*(it)];
+    if (score == 0.f) {
+      // ignore vectors if dot product is zero
+      continue;
+    }
+
+    float squared_norm = calc_column_squared_l2norm(*(it));
+
+    if (squared_norm == 0.f) {
+      // The column is already removed.
+      continue;
+    }
+
+    // `d2` is a squared euclidean distance.
+    // In edgy cases, `d2` may sliglty become negative (which is actually
+    // expected to be 0) due to the floating point precision problem.
+    // This cause `sqrt(d2)` to return NaN, which is not what we want.
+    // To avoid this we use `sqrt(max(0, d2))`.
+    float d2 = squared_query_norm + squared_norm - 2 * i_scores[*(it)];
+    heap.push(make_pair(-std::sqrt(std::max(0.f, d2)), *(it)));
+  }
+
+  vector<pair<float, uint64_t> > sorted_scores;
+  heap.get_sorted(sorted_scores);
+
+  for (size_t i = 0; i < sorted_scores.size() && i < ret_num; ++i) {
+    scores.push_back(
+		     make_pair(column2id_.get_key(sorted_scores[i].second),
+			       sorted_scores[i].first));
+  }
+}
+
+
 float inverted_index_storage::calc_l2norm(const common::sfv_t& sfv) {
   return std::sqrt(calc_squared_l2norm(sfv));
 }
@@ -474,6 +529,45 @@ void inverted_index_storage::add_inp_scores(
           ++row_it) {
         if (row_diff_v.find(row_it->first) == row_diff_v.end()) {
           scores[row_it->first] += row_it->second * val;
+        }
+      }
+    }
+  }
+}
+
+void inverted_index_storage::add_inp_scores(
+    const std::string& row,
+    float val,
+    std::vector<float>& scores,
+    unordered_set<int>& scores_index_set) const {
+  tbl_t::const_iterator it_diff = inv_diff_.find(row);
+  if (it_diff != inv_diff_.end()) {
+    const row_t& row_v = it_diff->second;
+    for (row_t::const_iterator row_it = row_v.begin(); row_it != row_v.end();
+	 ++row_it) {
+      scores[row_it->first] += row_it->second * val;
+      // records the row index when dot product is calculated
+      scores_index_set.insert(row_it->first);
+    }
+  }
+
+  tbl_t::const_iterator it = inv_.find(row);
+  if (it != inv_.end()) {
+    const row_t& row_v = it->second;
+    if (it_diff == inv_diff_.end()) {
+      for (row_t::const_iterator row_it = row_v.begin(); row_it != row_v.end();
+	   ++row_it) {
+        scores[row_it->first] += row_it->second * val;
+	// records the row index when dot product is calculated
+	scores_index_set.insert(row_it->first);
+      }
+    } else {
+      const row_t& row_diff_v = it_diff->second;
+      for (row_t::const_iterator row_it = row_v.begin(); row_it != row_v.end();
+	   ++row_it) {
+        if (row_diff_v.find(row_it->first) == row_diff_v.end()) {
+          scores[row_it->first] += row_it->second * val;
+	  scores_index_set.insert(row_it->first);
         }
       }
     }

--- a/jubatus/core/storage/inverted_index_storage.hpp
+++ b/jubatus/core/storage/inverted_index_storage.hpp
@@ -22,6 +22,7 @@
 #include <vector>
 #include <msgpack.hpp>
 #include "jubatus/util/data/unordered_map.h"
+#include "jubatus/util/data/unordered_set.h"
 #include "jubatus/util/lang/function.h"
 #include "jubatus/util/lang/bind.h"
 #include "storage_type.hpp"
@@ -74,6 +75,11 @@ class inverted_index_storage {
       std::vector<std::pair<std::string, float> >& scores,
       size_t ret_num) const;
 
+  void calc_euclid_scores_ignore_orthogonal(
+      const common::sfv_t& sfv,
+      std::vector<std::pair<std::string, float> >& scores,
+      size_t ret_num) const;
+
   void get_diff(diff_type& diff_str) const;
   bool put_diff(const diff_type& mixed_diff);
   void mix(const diff_type& lhs_str, diff_type& rhs_str) const;
@@ -104,6 +110,12 @@ class inverted_index_storage {
       const std::string& row,
       float val,
       std::vector<float>& scores) const;
+
+  void add_inp_scores(
+      const std::string& row,
+      float val,
+      std::vector<float>& scores,
+      util::data::unordered_set<int>& score_index_set) const;
 
   tbl_t inv_;
   tbl_t inv_diff_;


### PR DESCRIPTION
Fix #305.
I have added `ignore_orthogonal` option  to inverted index euclid.
When this option is true, recommender skips the score calculation between orthogonal vectors.
This option also accelerates `similar_row` when a lot of orthogonal vectors are registered.