### PR TITLE
add rwmutex sanity check to debug build

### DIFF
--- a/wscript
+++ b/wscript
@@ -72,6 +72,13 @@ def configure(conf):
     must be recompiled with this option.
     """
     # conf.define('_GLIBCXX_DEBUG', 1)
+
+    """
+    The following flag enables sanity check to detect double acquision of a read lock of pthread_rwlock
+    in the same thread.  More precisely, it raises assertion if the thread that already owns read lock
+    tries to take a read/write lock.
+    """
+    conf.define('JUBATUS_UTIL_CONCURRENT_RWMUTEX_ERRORCHECK', 1)
   else:
     # Disable standard assertions
     conf.define('NDEBUG', 1)


### PR DESCRIPTION
This PR introduces new compile-time flag called `JUBATUS_UTIL_CONCURRENT_RWMUTEX_ERRORCHECK`.
The flag is enabled by default when configured with `--enable-debug`.

When this flag is specified, each rwmutex class keep track of thread IDs that owns its read lock.
It raises assertion if the thread that already owns read lock tries to take a read/write lock.
So this enables sanity check to detect double acquision of a read lock of pthread_rwlock in the same thread.

This feature is intended to detect bugs seen in #199, #200, #303 etc.
