### PR TITLE
Improve configuration error message

### DIFF
--- a/jubatus/core/common/exception.cpp
+++ b/jubatus/core/common/exception.cpp
@@ -31,11 +31,10 @@ error_info_list_t jubatus_exception::error_info() const {
 std::string jubatus_exception::diagnostic_information(bool display_what) const {
   std::ostringstream tmp;
 
-  tmp << "Dynamic exception type: ";
   tmp << jubatus::util::lang::demangle(typeid(*this).name());
 
   if (display_what && strcmp(what(), "")) {
-    tmp << "::what: " << what();
+    tmp << ": " << what();
   }
 
   tmp << '\n';
@@ -47,7 +46,7 @@ std::string jubatus_exception::diagnostic_information(bool display_what) const {
       frame++;
       continue;
     }
-    tmp << "    #" << frame << " [" << (*it)->tag_typeid_name() << "] = "
+    tmp << "    (#" << frame << ") " << (*it)->tag() << ": "
         << (*it)->as_string() << '\n';
   }
   return tmp.str();

--- a/jubatus/core/common/exception.hpp
+++ b/jubatus/core/common/exception.hpp
@@ -319,6 +319,9 @@ inline exception_thrower_ptr get_current_exception() {
 }  // namespace exception
 
 class config_exception : public exception::jubaexception<config_exception> {
+  const char* what() const throw () {
+    return "invalid configuration";
+  }
 };
 
 class storage_not_set : public exception::jubaexception<storage_not_set> {

--- a/jubatus/core/common/exception.hpp
+++ b/jubatus/core/common/exception.hpp
@@ -35,10 +35,33 @@ namespace core {
 namespace common {
 namespace exception {
 
-typedef error_info<struct error_at_file_, std::string> error_at_file;
-typedef error_info<struct error_at_func_, std::string> error_at_func;
-typedef error_info<struct error_at_line_, int> error_at_line;
-typedef error_info<struct error_errno_, int> error_errno;
+DEFINE_ERROR_TAG(error_at_file, "Source", std::string)
+DEFINE_ERROR_TAG(error_at_func, "Function", std::string)
+DEFINE_ERROR_TAG(error_at_line, "Line", int)
+DEFINE_ERROR_TAG(error_errno, "Error", int)
+DEFINE_ERROR_TAG(error_file_name, "File", std::string)
+DEFINE_ERROR_TAG(error_api_func, "API", std::string)
+DEFINE_ERROR_TAG(error_message, "Message", std::string)
+DEFINE_ERROR_TAG(error_splitter, "Splitter", void)
+
+template<>
+class error_info<error_tag_error_splitter, void> : public error_info_base {
+ public:
+  bool splitter() const {
+    return true;
+  }
+
+  std::string tag() const {
+    return "Splitter";
+  }
+
+  std::string as_string() const {
+    // USE splitter or tag_typeid_name
+    return "-splitter-";
+  }
+};
+
+
 inline std::string to_string(const error_errno& info) {
   char buf[1024];
 #if defined(__linux__)
@@ -56,12 +79,6 @@ inline std::string to_string(const error_errno& info) {
     jubatus::util::lang::lexical_cast<std::string>(info.value()) + ")";
   return msg;
 }
-
-typedef error_info<struct error_file_name_, std::string> error_file_name;
-typedef error_info<struct error_api_func_, std::string> error_api_func;
-typedef error_info<struct error_message_, std::string> error_message;
-
-typedef error_info<struct error_splitter_, void> error_splitter;
 
 struct exception_thrower_binder_type {
 };

--- a/jubatus/core/common/exception_info.hpp
+++ b/jubatus/core/common/exception_info.hpp
@@ -29,13 +29,20 @@ namespace core {
 namespace common {
 namespace exception {
 
+#define DEFINE_ERROR_TAG(tagName, tagText, argType)             \
+  struct error_tag_##tagName {                                  \
+    const std::string name() { return tagText; }                \
+  };                                                            \
+  typedef jubatus::core::common::exception::error_info          \
+      <error_tag_##tagName, argType > tagName;
+
 class error_info_base {
  public:
   virtual bool splitter() const {
     return false;
   }
 
-  virtual std::string tag_typeid_name() const = 0;
+  virtual std::string tag() const = 0;
   virtual std::string as_string() const = 0;
 
   virtual ~error_info_base() throw () {
@@ -50,24 +57,6 @@ inline std::string to_string(const error_info<Tag, V>& info) {
   return jubatus::util::lang::lexical_cast<std::string, V>(info.value());
 }
 
-template<>
-class error_info<struct error_splitter_, void> : public error_info_base {
- public:
-  bool splitter() const {
-    return true;
-  }
-
-  std::string tag_typeid_name() const {
-    return jubatus::util::lang::demangle(
-        typeid(struct error_splitter_*).name());
-  }
-
-  std::string as_string() const {
-    // USE splitter or tag_typeid_name
-    return "-splitter-";
-  }
-};
-
 template<class Tag, class V>
 class error_info : public error_info_base {
  public:
@@ -75,7 +64,7 @@ class error_info : public error_info_base {
   explicit error_info(value_type v);
   ~error_info() throw ();
 
-  std::string tag_typeid_name() const;
+  std::string tag() const;
   std::string as_string() const;
 
   value_type value() const {
@@ -96,8 +85,8 @@ inline error_info<Tag, V>::~error_info() throw () {
 }
 
 template<class Tag, class V>
-inline std::string error_info<Tag, V>::tag_typeid_name() const {
-  return jubatus::util::lang::demangle(typeid(Tag*).name());
+inline std::string error_info<Tag, V>::tag() const {
+  return Tag().name();
 }
 
 template<class Tag, class V>

--- a/jubatus/core/common/exception_test.cpp
+++ b/jubatus/core/common/exception_test.cpp
@@ -36,7 +36,9 @@ namespace jubatus {
 namespace core {
 namespace common {
 namespace exception {
-typedef error_info<struct test_my_tag_, int> test_my_tag;
+
+DEFINE_ERROR_TAG(test_my_tag, "TestTag", int)
+
 inline string to_string(const test_my_tag& info) {
   return jubatus::util::lang::lexical_cast<string>(info.value() * 2);
 }


### PR DESCRIPTION
Supporse you have an invalid configuration file:

```json
{
  "method" : 123,
  "foo": 123
}
```

When running server with such config file, the server now displays error messages in format that is much easier to understand ...

```
$ jubaclassifier -f test.json
2016-08-23 12:10:23,034 11518 FATAL [server_util.hpp:146] exception in main thread: jubatus::core::common::config_exception: invalid configuration
    (#0) Message: "foo" is not used ()
    (#0) Message: String is expected, but Integer is given. (.method)
    (#0) Message: "converter" is not found ()
    (#0) Source: ../jubatus/server/server/../../server/framework/server_helper.hpp
    (#0) Line: 100
    (#0) Function: jubatus::server::framework::server_helper<Server>::server_helper(const jubatus::server::framework::server_argv&, bool) [with Server = jubatus::server::classifier_serv]
```

... instead of the current format:

```
2016-08-23 12:11:34,912 11704 FATAL [server_util.hpp:146] exception in main thread: Dynamic exception type: jubatus::core::common::config_exception::what: jubatus::core::common::config_exception
    #0 [jubatus::core::common::exception::error_message_*] = "foo" is not used ()
    #0 [jubatus::core::common::exception::error_message_*] = String is expected, but Integer is given. (.method)
    #0 [jubatus::core::common::exception::error_message_*] = "converter" is not found ()
    #0 [jubatus::core::common::exception::error_at_file_*] = ../jubatus/server/server/../../server/framework/server_helper.hpp
    #0 [jubatus::core::common::exception::error_at_line_*] = 100
    #0 [jubatus::core::common::exception::error_at_func_*] = jubatus::server::framework::server_helper<Server>::server_helper(const jubatus::server::framework::server_argv&, bool) [with Server = jubatus::server::classifier_serv]
```

Fix https://github.com/jubatus/jubatus/issues/405