### PR TITLE
fix inverted_index to rows cleared by clear_row correctly removed

### DIFF
--- a/jubatus/core/recommender/inverted_index.cpp
+++ b/jubatus/core/recommender/inverted_index.cpp
@@ -106,6 +106,7 @@ void inverted_index::remove_row(const std::string& id) {
   for (size_t i = 0; i < columns.size(); ++i) {
     inv.remove(columns[i].first, id);
   }
+  inv.mark_column_removed(id);
   orig_.remove_row(id);
 }
 

--- a/jubatus/core/storage/inverted_index_storage.cpp
+++ b/jubatus/core/storage/inverted_index_storage.cpp
@@ -115,6 +115,12 @@ float inverted_index_storage::get_from_tbl(
   }
 }
 
+/**
+ * Remove the record specified by row and column.
+ * If you remove the entire column, you need to first remove all records that
+ * belongs to the column via ``remove`` method, then use ``mark_column_removed``
+ * method to notify that the column was removed.
+ */
 void inverted_index_storage::remove(
     const std::string& row,
     const std::string& column) {
@@ -147,6 +153,25 @@ void inverted_index_storage::remove(
         }
       }
     }
+  }
+}
+
+/**
+ * This method notifies the storage that all records that belongs to the column
+ * was removed.  The caller is responsible to remove them before calling this
+ * method.
+ */
+void inverted_index_storage::mark_column_removed(const std::string& column) {
+  uint64_t column_id = column2id_.get_id_const(column);
+
+  if (column_id == common::key_manager::NOTFOUND) {
+    return;
+  }
+
+  if (column2norm_.count(column_id) == 0) {
+    column2norm_diff_.erase(column_id);
+  } else {
+    column2norm_diff_[column_id] = 0;
   }
 }
 

--- a/jubatus/core/storage/inverted_index_storage.cpp
+++ b/jubatus/core/storage/inverted_index_storage.cpp
@@ -171,7 +171,9 @@ void inverted_index_storage::mark_column_removed(const std::string& column) {
   if (column2norm_.count(column_id) == 0) {
     column2norm_diff_.erase(column_id);
   } else {
-    column2norm_diff_[column_id] = 0;
+    // To erase the column on next MIX (``put_diff``), "cancel" the diff value
+    // with the master value.
+    column2norm_diff_[column_id] = - column2norm_[column_id];
   }
 }
 
@@ -306,7 +308,7 @@ bool inverted_index_storage::put_diff(
       if (target != update_list.end() && target->second) {
         // unlearner admit to update
         column2norm_[column_index] += it->second;
-        if (column2norm_[column_index] == 0.f) {
+        if (column2norm_[column_index] <= 0.f) {
           column2norm_.erase(column_index);
         }
       } else {
@@ -318,7 +320,7 @@ bool inverted_index_storage::put_diff(
          it != mixed_diff.column2norm.end(); ++it) {
       uint64_t column_index = column2id_.get_id(it->first);
       column2norm_[column_index] += it->second;
-      if (column2norm_[column_index] == 0.f) {
+      if (column2norm_[column_index] <= 0.f) {
         column2norm_.erase(column_index);
       }
     }

--- a/jubatus/core/storage/inverted_index_storage.hpp
+++ b/jubatus/core/storage/inverted_index_storage.hpp
@@ -61,7 +61,7 @@ class inverted_index_storage {
   void set(const std::string& row, const std::string& column, float val);
   float get(const std::string& row, const std::string& column) const;
   void remove(const std::string& row, const std::string& column);
-  void remove_row(const std::string& row);
+  void mark_column_removed(const std::string& column);
   void clear();
   void get_all_column_ids(std::vector<std::string>& ids) const;
 

--- a/jubatus/core/storage/inverted_index_storage_test.cpp
+++ b/jubatus/core/storage/inverted_index_storage_test.cpp
@@ -21,6 +21,7 @@
 #include <gtest/gtest.h>
 #include "inverted_index_storage.hpp"
 #include "../framework/stream_writer.hpp"
+#include "jubatus/util/lang/cast.h"
 
 using std::make_pair;
 using std::pair;
@@ -28,6 +29,7 @@ using std::string;
 using std::stringstream;
 using std::sqrt;
 using std::vector;
+using jubatus::util::lang::lexical_cast;
 
 namespace jubatus {
 namespace core {
@@ -212,6 +214,79 @@ TEST(inverted_index_storage, mix) {
   EXPECT_EQ(0.0, s2.get("c2", "r1"));
   EXPECT_EQ(0.0, s2.get("c2", "r2"));
   EXPECT_EQ(1.0, s2.get("c2", "r3"));
+}
+
+TEST(inverted_index_storage, mix_removal) {
+  std::vector<std::string> ids;
+
+  // setup s1
+  inverted_index_storage s1;
+  s1.set("c1", "r1", 0.000001);
+  for (size_t i = 100; i < 1024; ++i) {
+    s1.set("c" + lexical_cast<std::string>(i), "r2", i);
+  }
+  s1.set("c2", "r3", 0.0001);
+
+  // setup s2
+  inverted_index_storage s2;
+  for (size_t i = 100; i < 1024; ++i) {
+    s1.set("c" + lexical_cast<std::string>(i), "r2", i);
+  }
+
+  // setup s3
+  inverted_index_storage s3;
+  s3.set("c1", "r4", 0.0001);
+
+  // MIX
+  inverted_index_storage::diff_type d1, d2, d3;
+  s1.get_diff(d1);
+  s2.get_diff(d2);
+  s3.get_diff(d3);
+  s1.mix(d3, d2);  // d3 --> d2
+  s1.mix(d2, d1);  // d2 --> d1
+  s1.put_diff(d1);
+  s2.put_diff(d1);
+  s3.put_diff(d1);
+
+  // rows must be registered in both storage
+  s1.get_all_column_ids(ids);
+  EXPECT_EQ(4, ids.size());  // r1, r2, r3, r4
+  s2.get_all_column_ids(ids);
+  EXPECT_EQ(4, ids.size());  // r1, r2, r3, r4
+  s3.get_all_column_ids(ids);
+  EXPECT_EQ(4, ids.size());  // r1, r2, r3, r4
+
+  // remove column ``r2``
+  for (size_t i = 100; i < 1024; ++i) {
+    s1.remove("c" + lexical_cast<std::string>(i), "r2");
+    s2.remove("c" + lexical_cast<std::string>(i), "r2");
+  }
+  s1.mark_column_removed("r2");
+  s2.mark_column_removed("r2");
+
+  // rows must not be removed from s1 before MIX
+  s1.get_all_column_ids(ids);
+  EXPECT_EQ(4, ids.size());  // r1, r2, r3, r4
+  s2.get_all_column_ids(ids);
+  EXPECT_EQ(4, ids.size());  // r1, r2, r3, r4
+
+  // MIX
+  s1.get_diff(d1);
+  s2.get_diff(d2);
+  s3.get_diff(d3);
+  s1.mix(d3, d2);  // d3 --> d2
+  s1.mix(d2, d1);  // d2 --> d1
+  s1.put_diff(d1);
+  s2.put_diff(d1);
+  s3.put_diff(d1);
+
+  // rows must be removed from both storage after MIX
+  s1.get_all_column_ids(ids);
+  EXPECT_EQ(3, ids.size());  // r1, r3, r4
+  s2.get_all_column_ids(ids);
+  EXPECT_EQ(3, ids.size());  // r1, r3, r4
+  s3.get_all_column_ids(ids);
+  EXPECT_EQ(3, ids.size());  // r1, r3, r4
 }
 
 TEST(inverted_index_storage, empty) {

--- a/jubatus/core/storage/inverted_index_storage_test.cpp
+++ b/jubatus/core/storage/inverted_index_storage_test.cpp
@@ -153,6 +153,7 @@ TEST(inverted_index_storage, column_operations) {
   EXPECT_EQ(3u, ids.size());
 
   s1.remove("c1", "r1");
+  s1.mark_column_removed("r1");
   s1.get_all_column_ids(ids);
   EXPECT_EQ(2u, ids.size());
 


### PR DESCRIPTION
Fixes https://github.com/jubatus/jubatus/issues/682.

This PR adds ``mark_column_removed`` API to ``storage::inverted_index_storage``.
Callers trying to remove the entire column (currently ``recommender::inverted_index`` only) must call it after removing all records that belongs to the column.

This PR also removes ``void remove_row(const std::string& row);``, which is declared in the header but not actually implemented.