### PR TITLE
refactoring parameter check on clustering feature (includes revert commit)

### DIFF
--- a/jubatus/core/clustering/clustering.cpp
+++ b/jubatus/core/clustering/clustering.cpp
@@ -43,55 +43,39 @@ clustering::clustering(
       method_(method),
       storage_() {
 
-  // TODO(@rimms): move to factory
-  if (method =="gmm" &&
-      cfg.compressor_method == "compressive_kmeans") {
-    throw JUBATUS_EXCEPTION(common::invalid_parameter(
-        "method = gmm, compressor_method != compressive_kmeans"));
-  }
-
-  // TODO(@rimms): move to factory
-  if (method =="kmeans" &&
-      cfg.compressor_method == "compressive_gmm") {
-    throw JUBATUS_EXCEPTION(common::invalid_parameter(
-        "method = kmeans, compressor_method != compressive_gmm"));
-  }
-
   if (!(1 <= cfg.k)) {
     throw JUBATUS_EXCEPTION(
         common::invalid_parameter("1 <= k"));
   }
 
-  if (!(2 <= cfg.bucket_size)) {
+  if (!(1 <= cfg.bucket_size)) {
     throw JUBATUS_EXCEPTION(
-        common::invalid_parameter("2 <= bucket_size"));
+        common::invalid_parameter("1 <= bucket_size"));
   }
 
-  if (!(2 <= cfg.bucket_length)) {
-    throw JUBATUS_EXCEPTION(
-        common::invalid_parameter("2 <= bucket_length"));
-  }
-
-  if (!(1 <= cfg.bicriteria_base_size &&
-      cfg.bicriteria_base_size < cfg.compressed_bucket_size)) {
-    throw JUBATUS_EXCEPTION(common::invalid_parameter(
-        "1 <= bicriteria_base_size < compressed_bucket_size"));
-  }
-
-  if (!(cfg.compressed_bucket_size < cfg.bucket_size)) {
-    throw JUBATUS_EXCEPTION(
-        common::invalid_parameter("compressed_bucket_size < bucket_size"));
-  }
-
-  if (!(0.0 <= cfg.forgetting_factor)) {
-    throw JUBATUS_EXCEPTION(
-        common::invalid_parameter("0.0 <= forgetting_factor"));
-  }
-
-  if (!(0.0 <= cfg.forgetting_threshold &&
-      cfg.forgetting_threshold <= 1.0)) {
-    throw JUBATUS_EXCEPTION(common::invalid_parameter(
-        "0.0 <= forgetting_threshold <= 1.0"));
+  if (cfg.compressor_method != "simple") {
+    if (!(2 <= cfg.bucket_length)) {
+      throw JUBATUS_EXCEPTION(
+          common::invalid_parameter("2 <= bucket_length"));
+    }
+    if (!(1 <= cfg.bicriteria_base_size &&
+          cfg.bicriteria_base_size < cfg.compressed_bucket_size)) {
+      throw JUBATUS_EXCEPTION(common::invalid_parameter(
+          "1 <= bicriteria_base_size < compressed_bucket_size"));
+    }
+    if (!(cfg.compressed_bucket_size < cfg.bucket_size)) {
+      throw JUBATUS_EXCEPTION(
+          common::invalid_parameter("compressed_bucket_size < bucket_size"));
+    }
+    if (!(0.0 <= cfg.forgetting_factor)) {
+      throw JUBATUS_EXCEPTION(
+          common::invalid_parameter("0.0 <= forgetting_factor"));
+    }
+    if (!(0.0 <= cfg.forgetting_threshold &&
+          cfg.forgetting_threshold <= 1.0)) {
+      throw JUBATUS_EXCEPTION(common::invalid_parameter(
+          "0.0 <= forgetting_threshold <= 1.0"));
+    }
   }
 
   init();
@@ -101,9 +85,9 @@ clustering::~clustering() {
 }
 
 void clustering::init() {
-  set_storage(storage_factory::create(name_, config_));
   set_clustering_method(
       clustering_method_factory::create(method_, config_));
+  set_storage(storage_factory::create(name_, method_, config_));
 }
 
 void clustering::set_storage(shared_ptr<storage> storage) {

--- a/jubatus/core/clustering/clustering.cpp
+++ b/jubatus/core/clustering/clustering.cpp
@@ -43,39 +43,55 @@ clustering::clustering(
       method_(method),
       storage_() {
 
+  // TODO(@rimms): move to factory
+  if (method =="gmm" &&
+      cfg.compressor_method == "compressive_kmeans") {
+    throw JUBATUS_EXCEPTION(common::invalid_parameter(
+        "method = gmm, compressor_method != compressive_kmeans"));
+  }
+
+  // TODO(@rimms): move to factory
+  if (method =="kmeans" &&
+      cfg.compressor_method == "compressive_gmm") {
+    throw JUBATUS_EXCEPTION(common::invalid_parameter(
+        "method = kmeans, compressor_method != compressive_gmm"));
+  }
+
   if (!(1 <= cfg.k)) {
     throw JUBATUS_EXCEPTION(
         common::invalid_parameter("1 <= k"));
   }
 
-  if (!(1 <= cfg.bucket_size)) {
+  if (!(2 <= cfg.bucket_size)) {
     throw JUBATUS_EXCEPTION(
-        common::invalid_parameter("1 <= bucket_size"));
+        common::invalid_parameter("2 <= bucket_size"));
   }
 
-  if (cfg.compressor_method != "simple") {
-    if (!(2 <= cfg.bucket_length)) {
-      throw JUBATUS_EXCEPTION(
-          common::invalid_parameter("2 <= bucket_length"));
-    }
-    if (!(1 <= cfg.bicriteria_base_size &&
-          cfg.bicriteria_base_size < cfg.compressed_bucket_size)) {
-      throw JUBATUS_EXCEPTION(common::invalid_parameter(
-          "1 <= bicriteria_base_size < compressed_bucket_size"));
-    }
-    if (!(cfg.compressed_bucket_size < cfg.bucket_size)) {
-      throw JUBATUS_EXCEPTION(
-          common::invalid_parameter("compressed_bucket_size < bucket_size"));
-    }
-    if (!(0.0 <= cfg.forgetting_factor)) {
-      throw JUBATUS_EXCEPTION(
-          common::invalid_parameter("0.0 <= forgetting_factor"));
-    }
-    if (!(0.0 <= cfg.forgetting_threshold &&
-          cfg.forgetting_threshold <= 1.0)) {
-      throw JUBATUS_EXCEPTION(common::invalid_parameter(
-          "0.0 <= forgetting_threshold <= 1.0"));
-    }
+  if (!(2 <= cfg.bucket_length)) {
+    throw JUBATUS_EXCEPTION(
+        common::invalid_parameter("2 <= bucket_length"));
+  }
+
+  if (!(1 <= cfg.bicriteria_base_size &&
+      cfg.bicriteria_base_size < cfg.compressed_bucket_size)) {
+    throw JUBATUS_EXCEPTION(common::invalid_parameter(
+        "1 <= bicriteria_base_size < compressed_bucket_size"));
+  }
+
+  if (!(cfg.compressed_bucket_size < cfg.bucket_size)) {
+    throw JUBATUS_EXCEPTION(
+        common::invalid_parameter("compressed_bucket_size < bucket_size"));
+  }
+
+  if (!(0.0 <= cfg.forgetting_factor)) {
+    throw JUBATUS_EXCEPTION(
+        common::invalid_parameter("0.0 <= forgetting_factor"));
+  }
+
+  if (!(0.0 <= cfg.forgetting_threshold &&
+      cfg.forgetting_threshold <= 1.0)) {
+    throw JUBATUS_EXCEPTION(common::invalid_parameter(
+        "0.0 <= forgetting_threshold <= 1.0"));
   }
 
   init();
@@ -85,9 +101,9 @@ clustering::~clustering() {
 }
 
 void clustering::init() {
+  set_storage(storage_factory::create(name_, config_));
   set_clustering_method(
       clustering_method_factory::create(method_, config_));
-  set_storage(storage_factory::create(name_, method_, config_));
 }
 
 void clustering::set_storage(shared_ptr<storage> storage) {

--- a/jubatus/core/clustering/clustering_test.cpp
+++ b/jubatus/core/clustering/clustering_test.cpp
@@ -66,7 +66,7 @@ TEST_P(clustering_test, config_validation) {
   if (param["result"] == "true") {
     ASSERT_NO_THROW(clustering k(n, m, c));
   } else {
-    ASSERT_THROW(clustering k(n, m, c), common::unsupported_method);
+    ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
     return;
   }
 
@@ -78,36 +78,21 @@ TEST_P(clustering_test, config_validation) {
   c.k = 2;
   ASSERT_NO_THROW(clustering k(n, m, c));
 
-  // simple storage's condition 1 <= bucket_size
-  // other storages's condition 1 <=
-  //       bucket_size && compressed_bucket_size < bucket_size
+  // 2 <= bucket_size
   c.compressed_bucket_size = 2;
   c.bicriteria_base_size = 1;
-  c.bucket_size = 0;
-  ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
   c.bucket_size = 1;
-  if (c.compressor_method == "simple") {
-    ASSERT_NO_THROW(clustering k(n, m, c));
-  } else {
-    ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
-  }
+  ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
+  // this case not will be passed;
   // (1 <= bicriteria_base_size < compressed_bucket_size < bucket_size)
-  c.bucket_size = 2;
-  if (c.compressor_method == "simple") {
-    ASSERT_NO_THROW(clustering k(n, m, c));
-  } else {
-    ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
-  }
+  // c.bucket_size = 2;
+  // ASSERT_NO_THROW(clustering k(n, m, c));
   c.bucket_size = 3;
   ASSERT_NO_THROW(clustering k(n, m, c));
 
   // 2 <= bucket_length
   c.bucket_length = 1;
-  if (c.compressor_method == "simple") {
-    ASSERT_NO_THROW(clustering k(n, m, c));
-  } else {
-    ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
-  }
+  ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
   c.bucket_length = 2;
   ASSERT_NO_THROW(clustering k(n, m, c));
   c.bucket_length = 3;
@@ -117,24 +102,11 @@ TEST_P(clustering_test, config_validation) {
   c.bucket_size = 4;
   c.compressed_bucket_size = 3;
   c.bicriteria_base_size = 0;
-  if (c.compressor_method == "simple") {
-    ASSERT_NO_THROW(clustering k(n, m, c));
-  } else {
-    ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
-  }
+  ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
   c.bicriteria_base_size = 3;
-    if (c.compressor_method == "simple") {
-    ASSERT_NO_THROW(clustering k(n, m, c));
-  } else {
-    ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
-  }
+  ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
   c.bicriteria_base_size = 4;
-  c.bicriteria_base_size = 3;
-    if (c.compressor_method == "simple") {
-    ASSERT_NO_THROW(clustering k(n, m, c));
-  } else {
-    ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
-  }
+  ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
   c.bicriteria_base_size = 1;
   ASSERT_NO_THROW(clustering k(n, m, c));
   c.bicriteria_base_size = 2;
@@ -142,33 +114,17 @@ TEST_P(clustering_test, config_validation) {
 
   // compressed_bucket_size < bucket_size
   c.compressed_bucket_size = 4;
-  if (c.compressor_method == "simple") {
-    ASSERT_NO_THROW(clustering k(n, m, c));
-  } else {
-    ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
-  }
+  ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
   c.compressed_bucket_size = 5;
-  if (c.compressor_method == "simple") {
-    ASSERT_NO_THROW(clustering k(n, m, c));
-  } else {
-    ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
-  }
+  ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
   c.compressed_bucket_size = 3;
   ASSERT_NO_THROW(clustering k(n, m, c));
 
   // 0.0 <= forgetting_factor
   c.forgetting_factor = std::numeric_limits<double>::quiet_NaN();
-  if (c.compressor_method == "simple") {
-    ASSERT_NO_THROW(clustering k(n, m, c));
-  } else {
-    ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
-  }
+  ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
   c.forgetting_factor = -1.0;
-  if (c.compressor_method == "simple") {
-    ASSERT_NO_THROW(clustering k(n, m, c));
-  } else {
-    ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
-  }
+  ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
   c.forgetting_factor = 0.0;
   ASSERT_NO_THROW(clustering k(n, m, c));
   c.forgetting_factor = 1.0;
@@ -176,17 +132,9 @@ TEST_P(clustering_test, config_validation) {
 
   // 0.0 <= forgetting_threshold <= 1.0
   c.forgetting_threshold = std::numeric_limits<double>::quiet_NaN();
-  if (c.compressor_method == "simple") {
-    ASSERT_NO_THROW(clustering k(n, m, c));
-  } else {
-    ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
-  }
+  ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
   c.forgetting_threshold = -1.0;
-  if (c.compressor_method == "simple") {
-    ASSERT_NO_THROW(clustering k(n, m, c));
-  } else {
-    ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
-  }
+  ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
   c.forgetting_threshold = 0.0;
   ASSERT_NO_THROW(clustering k(n, m, c));
   c.forgetting_threshold = 0.5;
@@ -194,11 +142,7 @@ TEST_P(clustering_test, config_validation) {
   c.forgetting_threshold = 1.0;
   ASSERT_NO_THROW(clustering k(n, m, c));
   c.forgetting_threshold = 2.0;
-  if (c.compressor_method == "simple") {
-    ASSERT_NO_THROW(clustering k(n, m, c));
-  } else {
-    ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
-  }
+  ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
 }
 
 

--- a/jubatus/core/clustering/clustering_test.cpp
+++ b/jubatus/core/clustering/clustering_test.cpp
@@ -66,7 +66,7 @@ TEST_P(clustering_test, config_validation) {
   if (param["result"] == "true") {
     ASSERT_NO_THROW(clustering k(n, m, c));
   } else {
-    ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
+    ASSERT_THROW(clustering k(n, m, c), common::unsupported_method);
     return;
   }
 
@@ -78,21 +78,36 @@ TEST_P(clustering_test, config_validation) {
   c.k = 2;
   ASSERT_NO_THROW(clustering k(n, m, c));
 
-  // 2 <= bucket_size
+  // simple storage's condition 1 <= bucket_size
+  // other storages's condition 1 <=
+  //       bucket_size && compressed_bucket_size < bucket_size
   c.compressed_bucket_size = 2;
   c.bicriteria_base_size = 1;
-  c.bucket_size = 1;
+  c.bucket_size = 0;
   ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
-  // this case not will be passed;
+  c.bucket_size = 1;
+  if (c.compressor_method == "simple") {
+    ASSERT_NO_THROW(clustering k(n, m, c));
+  } else {
+    ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
+  }
   // (1 <= bicriteria_base_size < compressed_bucket_size < bucket_size)
-  // c.bucket_size = 2;
-  // ASSERT_NO_THROW(clustering k(n, m, c));
+  c.bucket_size = 2;
+  if (c.compressor_method == "simple") {
+    ASSERT_NO_THROW(clustering k(n, m, c));
+  } else {
+    ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
+  }
   c.bucket_size = 3;
   ASSERT_NO_THROW(clustering k(n, m, c));
 
   // 2 <= bucket_length
   c.bucket_length = 1;
-  ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
+  if (c.compressor_method == "simple") {
+    ASSERT_NO_THROW(clustering k(n, m, c));
+  } else {
+    ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
+  }
   c.bucket_length = 2;
   ASSERT_NO_THROW(clustering k(n, m, c));
   c.bucket_length = 3;
@@ -102,11 +117,24 @@ TEST_P(clustering_test, config_validation) {
   c.bucket_size = 4;
   c.compressed_bucket_size = 3;
   c.bicriteria_base_size = 0;
-  ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
+  if (c.compressor_method == "simple") {
+    ASSERT_NO_THROW(clustering k(n, m, c));
+  } else {
+    ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
+  }
   c.bicriteria_base_size = 3;
-  ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
+    if (c.compressor_method == "simple") {
+    ASSERT_NO_THROW(clustering k(n, m, c));
+  } else {
+    ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
+  }
   c.bicriteria_base_size = 4;
-  ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
+  c.bicriteria_base_size = 3;
+    if (c.compressor_method == "simple") {
+    ASSERT_NO_THROW(clustering k(n, m, c));
+  } else {
+    ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
+  }
   c.bicriteria_base_size = 1;
   ASSERT_NO_THROW(clustering k(n, m, c));
   c.bicriteria_base_size = 2;
@@ -114,17 +142,33 @@ TEST_P(clustering_test, config_validation) {
 
   // compressed_bucket_size < bucket_size
   c.compressed_bucket_size = 4;
-  ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
+  if (c.compressor_method == "simple") {
+    ASSERT_NO_THROW(clustering k(n, m, c));
+  } else {
+    ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
+  }
   c.compressed_bucket_size = 5;
-  ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
+  if (c.compressor_method == "simple") {
+    ASSERT_NO_THROW(clustering k(n, m, c));
+  } else {
+    ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
+  }
   c.compressed_bucket_size = 3;
   ASSERT_NO_THROW(clustering k(n, m, c));
 
   // 0.0 <= forgetting_factor
   c.forgetting_factor = std::numeric_limits<double>::quiet_NaN();
-  ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
+  if (c.compressor_method == "simple") {
+    ASSERT_NO_THROW(clustering k(n, m, c));
+  } else {
+    ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
+  }
   c.forgetting_factor = -1.0;
-  ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
+  if (c.compressor_method == "simple") {
+    ASSERT_NO_THROW(clustering k(n, m, c));
+  } else {
+    ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
+  }
   c.forgetting_factor = 0.0;
   ASSERT_NO_THROW(clustering k(n, m, c));
   c.forgetting_factor = 1.0;
@@ -132,9 +176,17 @@ TEST_P(clustering_test, config_validation) {
 
   // 0.0 <= forgetting_threshold <= 1.0
   c.forgetting_threshold = std::numeric_limits<double>::quiet_NaN();
-  ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
+  if (c.compressor_method == "simple") {
+    ASSERT_NO_THROW(clustering k(n, m, c));
+  } else {
+    ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
+  }
   c.forgetting_threshold = -1.0;
-  ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
+  if (c.compressor_method == "simple") {
+    ASSERT_NO_THROW(clustering k(n, m, c));
+  } else {
+    ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
+  }
   c.forgetting_threshold = 0.0;
   ASSERT_NO_THROW(clustering k(n, m, c));
   c.forgetting_threshold = 0.5;
@@ -142,7 +194,11 @@ TEST_P(clustering_test, config_validation) {
   c.forgetting_threshold = 1.0;
   ASSERT_NO_THROW(clustering k(n, m, c));
   c.forgetting_threshold = 2.0;
-  ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
+  if (c.compressor_method == "simple") {
+    ASSERT_NO_THROW(clustering k(n, m, c));
+  } else {
+    ASSERT_THROW(clustering k(n, m, c), common::invalid_parameter);
+  }
 }
 
 

--- a/jubatus/core/clustering/storage_factory.cpp
+++ b/jubatus/core/clustering/storage_factory.cpp
@@ -29,42 +29,27 @@ namespace clustering {
 
 jubatus::util::lang::shared_ptr<storage> storage_factory::create(
     const std::string& name,
-    const std::string& method,
     const clustering_config& config) {
   typedef jubatus::util::lang::shared_ptr<storage> ptr;
   ptr ret;
-
-  if (method == "kmeans") {
-    if (config.compressor_method == "simple") {
-      simple_storage *s = new simple_storage(name, config);
-      ret.reset(s);
-    } else if (config.compressor_method == "compressive_kmeans") {
-      compressive_storage *s = new compressive_storage(name, config);
-      s->set_compressor(jubatus::util::lang::shared_ptr<compressor::compressor>(
-          new compressor::kmeans_compressor(config)));
-      ret.reset(s);
-    } else {
-      throw JUBATUS_EXCEPTION(
-          common::unsupported_method(config.compressor_method));
-    }
-  } else if (method == "gmm") {
-    if (config.compressor_method == "simple") {
-        simple_storage *s = new simple_storage(name, config);
-        ret.reset(s);
+  if (config.compressor_method == "compressive_kmeans") {
+    compressive_storage *s = new compressive_storage(name, config);
+    s->set_compressor(jubatus::util::lang::shared_ptr<compressor::compressor>(
+                          new compressor::kmeans_compressor(config)));
+    ret.reset(s);
 #ifdef JUBATUS_USE_EIGEN
-    } else if (config.compressor_method == "compressive_gmm") {
-      compressive_storage *s = new compressive_storage(name, config);
-      s->set_compressor(jubatus::util::lang::shared_ptr<compressor::compressor>(
-          new compressor::gmm_compressor(config)));
-      ret.reset(s);
+  } else if (config.compressor_method == "compressive_gmm") {
+    compressive_storage *s = new compressive_storage(name, config);
+    s->set_compressor(jubatus::util::lang::shared_ptr<compressor::compressor>(
+                          new compressor::gmm_compressor(config)));
+    ret.reset(s);
 #endif
-    } else {
-      throw JUBATUS_EXCEPTION(
-          common::unsupported_method(config.compressor_method));
-    }
+  } else if (config.compressor_method == "simple") {
+    simple_storage *s = new simple_storage(name, config);
+    ret.reset(s);
   } else {
-      throw JUBATUS_EXCEPTION(
-          common::unsupported_method(method));
+    throw JUBATUS_EXCEPTION(
+        common::unsupported_method(config.compressor_method));
   }
   return ret;
 }

--- a/jubatus/core/clustering/storage_factory.cpp
+++ b/jubatus/core/clustering/storage_factory.cpp
@@ -29,27 +29,42 @@ namespace clustering {
 
 jubatus::util::lang::shared_ptr<storage> storage_factory::create(
     const std::string& name,
+    const std::string& method,
     const clustering_config& config) {
   typedef jubatus::util::lang::shared_ptr<storage> ptr;
   ptr ret;
-  if (config.compressor_method == "compressive_kmeans") {
-    compressive_storage *s = new compressive_storage(name, config);
-    s->set_compressor(jubatus::util::lang::shared_ptr<compressor::compressor>(
-                          new compressor::kmeans_compressor(config)));
-    ret.reset(s);
+
+  if (method == "kmeans") {
+    if (config.compressor_method == "simple") {
+      simple_storage *s = new simple_storage(name, config);
+      ret.reset(s);
+    } else if (config.compressor_method == "compressive_kmeans") {
+      compressive_storage *s = new compressive_storage(name, config);
+      s->set_compressor(jubatus::util::lang::shared_ptr<compressor::compressor>(
+          new compressor::kmeans_compressor(config)));
+      ret.reset(s);
+    } else {
+      throw JUBATUS_EXCEPTION(
+          common::unsupported_method(config.compressor_method));
+    }
+  } else if (method == "gmm") {
+    if (config.compressor_method == "simple") {
+        simple_storage *s = new simple_storage(name, config);
+        ret.reset(s);
 #ifdef JUBATUS_USE_EIGEN
-  } else if (config.compressor_method == "compressive_gmm") {
-    compressive_storage *s = new compressive_storage(name, config);
-    s->set_compressor(jubatus::util::lang::shared_ptr<compressor::compressor>(
-                          new compressor::gmm_compressor(config)));
-    ret.reset(s);
+    } else if (config.compressor_method == "compressive_gmm") {
+      compressive_storage *s = new compressive_storage(name, config);
+      s->set_compressor(jubatus::util::lang::shared_ptr<compressor::compressor>(
+          new compressor::gmm_compressor(config)));
+      ret.reset(s);
 #endif
-  } else if (config.compressor_method == "simple") {
-    simple_storage *s = new simple_storage(name, config);
-    ret.reset(s);
+    } else {
+      throw JUBATUS_EXCEPTION(
+          common::unsupported_method(config.compressor_method));
+    }
   } else {
-    throw JUBATUS_EXCEPTION(
-        common::unsupported_method(config.compressor_method));
+      throw JUBATUS_EXCEPTION(
+          common::unsupported_method(method));
   }
   return ret;
 }

--- a/jubatus/core/clustering/storage_factory.hpp
+++ b/jubatus/core/clustering/storage_factory.hpp
@@ -30,6 +30,7 @@ class storage_factory {
  public:
   static jubatus::util::lang::shared_ptr<storage> create(
       const std::string& name,
+      const std::string& method,
       const clustering_config& config);
 };
 

--- a/jubatus/core/clustering/storage_factory.hpp
+++ b/jubatus/core/clustering/storage_factory.hpp
@@ -30,7 +30,6 @@ class storage_factory {
  public:
   static jubatus::util::lang::shared_ptr<storage> create(
       const std::string& name,
-      const std::string& method,
       const clustering_config& config);
 };
 


### PR DESCRIPTION
fix #314

if compressor_method is simple, bucket_length, compressed_bucket_size,bicriteria_base_size,forgetting_factor,forgetting_threshold are ignored.

In addtion, modify bucket_size range
modify bucket_size range from 2<=bucket_size to 1<=bucket_size.

(This PR includes revert commit for develop, master branch)