### PR TITLE
Refactoring Clustering API and config value

### DIFF
--- a/jubatus/core/clustering/clustering_test.cpp
+++ b/jubatus/core/clustering/clustering_test.cpp
@@ -209,14 +209,14 @@ const map<string, string> test_cases[] = {
     ("compressor_method", "compressive_kmeans")
     ("result", "false")(),
   make_case("method", "gmm")
-    ("compressor_method", "compressive_gmm")
+    ("compressor_method", "compressive")
     ("result", "true")(),
   make_case("method", "gmm")
     ("compressor_method", "simple")
     ("result", "true")(),
 #endif
   make_case("method", "kmeans")
-    ("compressor_method", "compressive_kmeans")
+    ("compressor_method", "compressive")
     ("result", "true")(),
   make_case("method", "kmeans")
     ("compressor_method", "compressive_gmm")

--- a/jubatus/core/clustering/mixable_model_test.cpp
+++ b/jubatus/core/clustering/mixable_model_test.cpp
@@ -31,7 +31,7 @@ class mixable_model_test : public ::testing::Test {
   mixable_model_test() : name_("name") {
     clustering_config cfg;
     cfg.k = 3;
-    cfg.compressor_method = "compressive_kmeans";
+    cfg.compressor_method = "compressive";
     cfg.bucket_size = 10000;
     cfg.compressed_bucket_size = 400;
 

--- a/jubatus/core/clustering/model_gmm_test.cpp
+++ b/jubatus/core/clustering/model_gmm_test.cpp
@@ -35,7 +35,7 @@ class model_gmm_test : public ::testing::Test {
 
   model_gmm_test() {
     config_.k = k_;
-    config_.compressor_method = "compressive_gmm";
+    config_.compressor_method = "compressive";
     config_.bucket_size = 100;
     config_.compressed_bucket_size = 5;
     config_.bicriteria_base_size = 1;

--- a/jubatus/core/clustering/model_test.cpp
+++ b/jubatus/core/clustering/model_test.cpp
@@ -36,7 +36,7 @@ class model_test : public ::testing::Test {
 
   model_test() {
     config_.k = 3;
-    config_.compressor_method = "compressive_kmeans";
+    config_.compressor_method = "compressive";
     config_.bucket_size = 10000;
     config_.compressed_bucket_size = 100;
     config_.forgetting_threshold = 0.05;

--- a/jubatus/core/clustering/storage_factory.cpp
+++ b/jubatus/core/clustering/storage_factory.cpp
@@ -38,7 +38,7 @@ jubatus::util::lang::shared_ptr<storage> storage_factory::create(
     if (config.compressor_method == "simple") {
       simple_storage *s = new simple_storage(name, config);
       ret.reset(s);
-    } else if (config.compressor_method == "compressive_kmeans") {
+    } else if (config.compressor_method == "compressive") {
       compressive_storage *s = new compressive_storage(name, config);
       s->set_compressor(jubatus::util::lang::shared_ptr<compressor::compressor>(
           new compressor::kmeans_compressor(config)));
@@ -52,7 +52,7 @@ jubatus::util::lang::shared_ptr<storage> storage_factory::create(
         simple_storage *s = new simple_storage(name, config);
         ret.reset(s);
 #ifdef JUBATUS_USE_EIGEN
-    } else if (config.compressor_method == "compressive_gmm") {
+    } else if (config.compressor_method == "compressive") {
       compressive_storage *s = new compressive_storage(name, config);
       s->set_compressor(jubatus::util::lang::shared_ptr<compressor::compressor>(
           new compressor::gmm_compressor(config)));

--- a/jubatus/core/clustering/storage_test.cpp
+++ b/jubatus/core/clustering/storage_test.cpp
@@ -108,14 +108,14 @@ TEST_P(storage_test, pack_unpack) {
 const std::map<std::string, std::string> test_cases[] = {
 #ifdef JUBATUS_USE_EIGEN
   make_case("method", "gmm")
-    ("compressor_method", "compressive_gmm")
+    ("compressor_method", "compressive")
     ("result", "true")(),
   make_case("method", "gmm")
     ("compressor_method", "simple")
     ("result", "true")(),
 #endif
   make_case("method", "kmeans")
-    ("compressor_method", "compressive_kmeans")
+    ("compressor_method", "compressive")
     ("result", "true")(),
   make_case("method", "kmeans")
     ("compressor_method", "simple")

--- a/jubatus/core/clustering/types.hpp
+++ b/jubatus/core/clustering/types.hpp
@@ -34,18 +34,30 @@ namespace clustering {
 typedef double cluster_weight;
 typedef std::vector<std::pair<cluster_weight,
             jubatus::core::fv_converter::datum> > cluster_unit;
+typedef std::vector<std::pair<cluster_weight,
+                              std::string> > index_cluster_unit;
 typedef std::vector<cluster_unit> cluster_set;
+typedef std::vector<index_cluster_unit> index_cluster_set;
 
 struct weighted_point {
  public:
-  MSGPACK_DEFINE(weight, data, original);
+  MSGPACK_DEFINE(id, weight, data, original);
+  std::string id;
   double weight;
   common::sfv_t data;
   fv_converter::datum original;
 };
 
+struct indexed_point {
+ public:
+  MSGPACK_DEFINE(id, point);
+  std::string id;
+  fv_converter::datum point;
+};
+
 inline void swap(weighted_point& p1, weighted_point& p2) {
   using std::swap;
+  swap(p1.id, p2.id);
   swap(p1.weight, p2.weight);
   swap(p1.data, p2.data);
   swap(p1.original.string_values_, p2.original.string_values_);

--- a/jubatus/core/driver/clustering.cpp
+++ b/jubatus/core/driver/clustering.cpp
@@ -53,8 +53,8 @@ clustering::clustering(
 clustering::~clustering() {
 }
 
-void clustering::push(const vector<datum>& points) {
-  clustering_->push(to_weighted_point_vector(points));
+void clustering::push(const vector<core::clustering::indexed_point>& points) {
+  clustering_->push(to_weighted_indexed_point_vector(points));
 }
 
 datum clustering::get_nearest_center(
@@ -66,6 +66,12 @@ datum clustering::get_nearest_center(
 core::clustering::cluster_unit
     clustering::get_nearest_members(const datum& point) const {
   return to_weighted_datum_vector(
+      clustering_->get_nearest_members(to_sfv_const(point)));
+}
+
+core::clustering::index_cluster_unit
+clustering::get_nearest_members_light(const datum& point) const {
+  return to_weighted_index_vector(
       clustering_->get_nearest_members(to_sfv_const(point)));
 }
 
@@ -91,6 +97,24 @@ clustering::get_core_members() const {
   return ret;
 }
 
+core::clustering::index_cluster_set
+clustering::get_core_members_light() const {
+  vector<vector<core::clustering::weighted_point> > src =
+      clustering_->get_core_members();
+
+  core::clustering::index_cluster_set ret;
+  ret.reserve(src.size());
+  std::transform(
+      src.begin(),
+      src.end(),
+      std::back_inserter(ret),
+      jubatus::util::lang::bind(
+          &clustering::to_weighted_index_vector,
+          this, jubatus::util::lang::_1));
+
+  return ret;
+}
+
 size_t clustering::get_revision() const {
   return clustering_->get_revision();
 }
@@ -108,6 +132,7 @@ common::sfv_t clustering::to_sfv(const datum& dat) {
   return ret;
 }
 
+
 common::sfv_t clustering::to_sfv_const(const datum& dat) const {
   common::sfv_t ret;
   converter_->convert(dat, ret);
@@ -121,6 +146,17 @@ datum clustering::to_datum(const common::sfv_t& src) const {
   return ret;
 }
 
+
+pair<double, datum> clustering::to_weighted_datum(
+  const core::clustering::weighted_point& src) const {
+  return std::make_pair(src.weight, src.original);
+}
+
+pair<double, std::string> clustering::to_weighted_index(
+    const core::clustering::weighted_point& src) const {
+  return std::make_pair(src.weight, src.id);
+}
+
 core::clustering::weighted_point clustering::to_weighted_point(
     const datum& src) {
   core::clustering::weighted_point ret;
@@ -130,9 +166,14 @@ core::clustering::weighted_point clustering::to_weighted_point(
   return ret;
 }
 
-pair<double, datum> clustering::to_weighted_datum(
-  const core::clustering::weighted_point& src) const {
-  return std::make_pair(src.weight, src.original);
+core::clustering::weighted_point clustering::to_weighted_indexed_point(
+    const core::clustering::indexed_point& src) {
+  core::clustering::weighted_point ret;
+  ret.id = src.id;
+  ret.data = to_sfv(src.point);
+  ret.weight = 1;
+  ret.original = src.point;
+  return ret;
 }
 
 vector<datum> clustering::to_datum_vector(
@@ -150,8 +191,8 @@ vector<datum> clustering::to_datum_vector(
 }
 
 vector<core::clustering::weighted_point>
-  clustering::to_weighted_point_vector(
-  const vector<datum>& src) {
+clustering::to_weighted_point_vector(
+    const vector<datum>& src) {
   vector<core::clustering::weighted_point> ret;
   ret.reserve(src.size());
   std::transform(
@@ -164,8 +205,23 @@ vector<core::clustering::weighted_point>
   return ret;
 }
 
+vector<core::clustering::weighted_point>
+  clustering::to_weighted_indexed_point_vector(
+      const vector<core::clustering::indexed_point>& src) {
+  vector<core::clustering::weighted_point> ret;
+  ret.reserve(src.size());
+  std::transform(
+      src.begin(),
+      src.end(),
+      std::back_inserter(ret),
+      jubatus::util::lang::bind(
+          &clustering::to_weighted_indexed_point,
+          this, jubatus::util::lang::_1));
+  return ret;
+}
+
 core::clustering::cluster_unit
-  clustering::to_weighted_datum_vector(
+clustering::to_weighted_datum_vector(
     const vector<core::clustering::weighted_point>& src) const {
   core::clustering::cluster_unit ret;
   ret.reserve(src.size());
@@ -176,6 +232,22 @@ core::clustering::cluster_unit
       jubatus::util::lang::bind(
           &clustering::to_weighted_datum,
           this, jubatus::util::lang::_1));
+  return ret;
+}
+
+core::clustering::index_cluster_unit
+clustering::to_weighted_index_vector(
+    const vector<core::clustering::weighted_point>& src) const {
+  core::clustering::index_cluster_unit ret;
+  ret.reserve(src.size());
+  std::transform(
+      src.begin(),
+      src.end(),
+      std::back_inserter(ret),
+      jubatus::util::lang::bind(
+          &clustering::to_weighted_index,
+          this, jubatus::util::lang::_1));
+
   return ret;
 }
 

--- a/jubatus/core/driver/clustering.hpp
+++ b/jubatus/core/driver/clustering.hpp
@@ -46,15 +46,18 @@ class clustering : public driver_base {
           converter);
   virtual ~clustering();
 
-  void push(const std::vector<fv_converter::datum>& points);
+  void push(const std::vector<core::clustering::indexed_point>& points);
 
   fv_converter::datum get_nearest_center(
       const fv_converter::datum& point) const;
   core::clustering::cluster_unit get_nearest_members(
     const fv_converter::datum& point) const;
+  core::clustering::index_cluster_unit get_nearest_members_light(
+      const fv_converter::datum& point) const;
 
   std::vector<fv_converter::datum> get_k_center() const;
   core::clustering::cluster_set get_core_members() const;
+  core::clustering::index_cluster_set get_core_members_light() const;
 
   size_t get_revision() const;
   void pack(framework::packer& pk) const;
@@ -71,13 +74,21 @@ class clustering : public driver_base {
   fv_converter::datum to_datum(const common::sfv_t& src) const;
   core::clustering::weighted_point to_weighted_point(
       const fv_converter::datum& src);
+  core::clustering::weighted_point to_weighted_indexed_point(
+      const core::clustering::indexed_point& src);
   std::pair<double, fv_converter::datum>
   to_weighted_datum(const core::clustering::weighted_point& src) const;
+  std::pair<double, std::string>
+  to_weighted_index(const core::clustering::weighted_point& src) const;
   std::vector<fv_converter::datum> to_datum_vector(
       const std::vector<common::sfv_t>& src) const;
   std::vector<core::clustering::weighted_point> to_weighted_point_vector(
       const std::vector<fv_converter::datum>& src);
+  std::vector<core::clustering::weighted_point> to_weighted_indexed_point_vector(
+      const std::vector<core::clustering::indexed_point>& src);
   core::clustering::cluster_unit to_weighted_datum_vector(
+      const std::vector<core::clustering::weighted_point>& src) const;
+  core::clustering::index_cluster_unit to_weighted_index_vector(
       const std::vector<core::clustering::weighted_point>& src) const;
 
   jubatus::util::lang::shared_ptr<fv_converter::datum_to_fv_converter>

--- a/jubatus/core/driver/clustering_test.cpp
+++ b/jubatus/core/driver/clustering_test.cpp
@@ -541,10 +541,10 @@ TEST_P(clustering_test, empty_mix) {
 vector<pair<string, string> > parameter_list() {
   vector<pair<string, string> > ret;
   ret.push_back(make_pair("simple", "kmeans"));
-  ret.push_back(make_pair("compressive_kmeans", "kmeans"));
+  ret.push_back(make_pair("compressive", "kmeans"));
 #ifdef JUBATUS_USE_EIGEN
   ret.push_back(make_pair("simple", "gmm"));
-  ret.push_back(make_pair("compressive_gmm", "gmm"));
+  ret.push_back(make_pair("compressive", "gmm"));
 #endif
   return ret;
 }

--- a/jubatus/core/driver/clustering_test.cpp
+++ b/jubatus/core/driver/clustering_test.cpp
@@ -29,6 +29,7 @@
 #include "jubatus/util/lang/cast.h"
 #include "../clustering/clustering_config.hpp"
 #include "../clustering/clustering.hpp"
+#include "../clustering/types.hpp"
 #include "../clustering/kmeans_clustering_method.hpp"
 #include "../clustering/gmm_clustering_method.hpp"
 #include "../framework/stream_writer.hpp"
@@ -90,14 +91,20 @@ datum single_datum(string key, double v) {
   d.num_values_.push_back(make_pair(key, v));
   return d;
 }
+core::clustering::indexed_point single_indexed_point(string id, datum datum) {
+  core::clustering::indexed_point p;
+  p.id = id;
+  p.point = datum;
+  return p;
+}
 }
 
 TEST_P(clustering_test, get_revision) {
   const int num = conf_.bucket_size * 10;
   for (int i = 0; i < num; ++i) {
-    vector<datum> datums;
-    datums.push_back(single_datum("a", 1));
-    clustering_->push(datums);
+    vector<core::clustering::indexed_point> points;
+    points.push_back(single_indexed_point(lexical_cast<string>(i),single_datum("a", 1)));
+    clustering_->push(points);
   }
   std::size_t expected = num / conf_.bucket_size;
   ASSERT_EQ(expected, clustering_->get_revision());
@@ -105,23 +112,36 @@ TEST_P(clustering_test, get_revision) {
 
 TEST_P(clustering_test, push) {
   for (int j = 0; j < conf_.bucket_size / 5; ++j) {
-    vector<datum> datums;
+    vector<core::clustering::indexed_point> points;
     for (int i = 0; i < 100; i += 5) {
-      datums.push_back(single_datum("a", i * 2));
-      datums.push_back(single_datum("b", i * 100));
+      points.push_back(single_indexed_point(lexical_cast<string>(i),single_datum("a", i * 2)));
+      points.push_back(single_indexed_point(lexical_cast<string>(i),single_datum("a", i * 2)));
     }
-    clustering_->push(datums);
+    clustering_->push(points);
   }
+}
+
+TEST_P(clustering_test, push_indexed_point) {
+  vector<core::clustering::indexed_point> points;
+  const int num = conf_.bucket_size * 10;
+  int skip = 5;
+  for (int i = 0; i < num; i += skip) {
+    datum d = single_datum("a", i * 2);
+    points.push_back(single_indexed_point(lexical_cast<string>(i), d));
+  }
+  clustering_->push(points);
+  std::size_t expected = num / skip / conf_.bucket_size ;
+  ASSERT_EQ(expected, clustering_->get_revision());
 }
 
 TEST_P(clustering_test, save_load) {
   {
     core::fv_converter::datum d;
-    vector<datum> datums;
-    datums.push_back(single_datum("a", 1));
-    clustering_->push(datums);
+    vector<core::clustering::indexed_point> points;
+    points.push_back(single_indexed_point(lexical_cast<string>(1),single_datum("a", 1)));
+    clustering_->push(points);
   }
-
+  
   // save to a buffer
   msgpack::sbuffer sbuf;
   framework::stream_writer<msgpack::sbuffer> st(sbuf);
@@ -142,9 +162,9 @@ TEST_P(clustering_test, save_load) {
 TEST_P(clustering_test, clear) {
   const int num = conf_.bucket_size * 10;
   for (int i = 0; i < num; ++i) {
-    vector<datum> datums;
-    datums.push_back(single_datum("a", 1));
-    clustering_->push(datums);
+    vector<core::clustering::indexed_point> points;
+    points.push_back(single_indexed_point(lexical_cast<string>(i),single_datum("a", 1)));
+    clustering_->push(points);
   }
 
   clustering_->clear();
@@ -165,13 +185,13 @@ TEST_P(clustering_test, get_k_center) {
     b.num_values_.push_back(make_pair("c", 50000 + r.next_gaussian() * 100));
     b.num_values_.push_back(make_pair("d", 250000 + r.next_gaussian() * 500));
 
-    vector<datum> one;
-    one.push_back(a);
+    vector<core::clustering::indexed_point> one;
+    one.push_back(single_indexed_point("1",a));
     clustering_->push(one);
     one.clear();
 
-    vector<datum> two;
-    two.push_back(b);
+    vector<core::clustering::indexed_point> two;
+    two.push_back(single_indexed_point("2",b));
     clustering_->push(two);
     two.clear();
   }
@@ -181,7 +201,7 @@ TEST_P(clustering_test, get_k_center) {
     vector<datum> result = clustering_->get_k_center();
     ASSERT_EQ(std::size_t(conf_.k), result.size());
     ASSERT_LT(1U, result[0].num_values_.size());
-
+    
     // two center should be far about sqrt(100^2 + 200^2 + 5000^2 + 250000^2)
     double squared_diff = 0;
     std::vector<map<string, double> > centers;
@@ -209,27 +229,27 @@ TEST_P(clustering_test, get_k_center) {
 TEST_P(clustering_test, integer_center) {
   jubatus::util::math::random::mtrand r(0);
   const int quantity = conf_.bucket_size * 5;
-  std::vector<datum> data(quantity);
+  std::vector<core::clustering::indexed_point> data(quantity);
 
   for (int i = 0; i < quantity ; ++i) {
-    data[i].num_values_.push_back(make_pair("x", 100 + r.next_int(-10, 10)));
+    data[i].point.num_values_.push_back(make_pair("x", 100 + r.next_int(-10, 10)));
+    data[i].id = lexical_cast<string>(i);
   }
 
   clustering_->push(data);
   const std::vector<fv_converter::datum> centers = clustering_->get_k_center();
 
   ASSERT_EQ(std::size_t(conf_.k), centers.size());
-  /*  debug out
-  for (size_t i = 0; i < centers.size(); ++i) {
-    std::cout << i << " :[";
-    for (size_t j = 0; j < centers[i].num_values_.size(); ++j) {
-      std::cout
-        << centers[i].num_values_[j].first << " => "
-        << centers[i].num_values_[j].second << ", ";
-    }
-    std::cout << "]" << std::endl;;
-  }
-  //*/
+  //debug out
+  // for (size_t i = 0; i < centers.size(); ++i) {
+  //   std::cout << i << " :[";
+  //   for (size_t j = 0; j < centers[i].num_values_.size(); ++j) {
+  //     std::cout
+  //       << centers[i].num_values_[j].first << " => "
+  //       << centers[i].num_values_[j].second << ", ";
+  //   }
+  //   std::cout << "]" << std::endl;;
+  // }
 }
 
 struct check_points {
@@ -273,13 +293,13 @@ TEST_P(clustering_test, get_nearest_members) {
     y.num_values_.push_back(make_pair("c", -5000 - r.next_gaussian() * 100));
     y.num_values_.push_back(make_pair("d", -1000 - r.next_gaussian() * 50));
 
-    vector<datum> one;
-    one.push_back(x);
+    vector<core::clustering::indexed_point> one;
+    one.push_back(single_indexed_point(lexical_cast<string>(2*i), x));
     clustering_->push(one);
     one.clear();
 
-    vector<datum> two;
-    two.push_back(y);
+    vector<core::clustering::indexed_point> two;
+    two.push_back(single_indexed_point(lexical_cast<string>(2*i+1), y));
     clustering_->push(two);
     two.clear();
   }
@@ -336,7 +356,99 @@ TEST_P(clustering_test, get_nearest_members) {
   }
 }
 
+TEST_P(clustering_test, get_nearest_members_light) {
+  jubatus::util::math::random::mtrand r(0);
 
+  for (int i = 0; i < conf_.bucket_size * 2 + 1; ++i) {
+    datum x, y;
+    float a = 100 + r.next_gaussian() * 20;
+    float b = 1000 + r.next_gaussian() * 400;
+
+    x.num_values_.push_back(make_pair("a", a));
+    x.num_values_.push_back(make_pair("b", b));
+    y.num_values_.push_back(make_pair("c", -5000 - r.next_gaussian() * 100));
+    y.num_values_.push_back(make_pair("d", -1000 - r.next_gaussian() * 50));
+    
+    vector<core::clustering::indexed_point> one;
+    one.push_back(single_indexed_point(lexical_cast<string>(2*i), x));
+    clustering_->push(one);
+    one.clear();
+
+    vector<core::clustering::indexed_point> two;
+    two.push_back(single_indexed_point(lexical_cast<string>(2*i+1),y));
+    clustering_->push(two);
+    two.clear();
+  }
+
+  clustering_->do_clustering();
+  {
+    vector<datum> result = clustering_->get_k_center();
+    ASSERT_EQ(std::size_t(conf_.k), result.size());
+    std::cout << "cluster size : " << result.size() << std::endl;
+  }
+
+  datum x;
+  x.num_values_.push_back(make_pair("a", 100));
+  x.num_values_.push_back(make_pair("b", 1000));
+  core::clustering::index_cluster_unit result =
+      clustering_->get_nearest_members_light(x);
+  // std::cout << " ["; //debug out
+  for (size_t i = 0; i < result.size(); ++i) {
+      // std::cout
+      //   << result[i].first << " => "
+      //   << result[i].second << ", ";
+      ASSERT_EQ((lexical_cast<int>(result[i].second)%2), 0);
+  }
+  // std::cout << "]" << std::endl;
+}
+
+TEST_P(clustering_test, get_core_members_light) {
+  jubatus::util::math::random::mtrand r(0);
+  int data_num = 50;
+  
+  for (int i = 0; i < data_num; ++i) {
+    datum x, y;
+
+    x.num_values_.push_back(make_pair("a", 100 + r.next_gaussian() * 20));
+    x.num_values_.push_back(make_pair("b", 1000 + r.next_gaussian() * 400));
+    y.num_values_.push_back(make_pair("c", -5000 - r.next_gaussian() * 100));
+    y.num_values_.push_back(make_pair("d", -1000 - r.next_gaussian() * 50));
+
+    vector<core::clustering::indexed_point> one;
+    one.push_back(single_indexed_point(lexical_cast<string>(2*i), x));
+    clustering_->push(one);
+    one.clear();
+
+    vector<core::clustering::indexed_point> two;
+    two.push_back(single_indexed_point(lexical_cast<string>(2*i+1),y));
+    clustering_->push(two);
+    two.clear();
+  }
+  
+  clustering_->do_clustering();
+
+  core::clustering::index_cluster_set result =
+      clustering_->get_core_members_light();
+  ASSERT_EQ(std::size_t(conf_.k), result.size());
+  ASSERT_EQ(std::size_t(data_num), result[0].size());
+  ASSERT_EQ(std::size_t(data_num), result[1].size());
+  
+  for (size_t i = 0; i < result.size(); ++i) {
+    // std::cout << i << " :["; //debug out
+    if (lexical_cast<int>(result[i][0].second)%2 == 0) {
+      for (size_t j = 1; j < result[i].size(); ++j)  {
+        ASSERT_EQ(0, lexical_cast<int>(result[i][0].second)%2);
+        // std::cout << result[i][j].second << ", ";
+      }
+    } else {
+      for (size_t j = 1; j < result[i].size(); ++j)  {
+        ASSERT_EQ(1, lexical_cast<int>(result[i][0].second)%2);
+        // std::cout << result[i][j].second << ", ";
+      }
+    }
+    // std::cout << "]" << std::endl;
+  }
+}
 
 TEST_P(clustering_test, get_nearest_center) {
   jubatus::util::math::random::mtrand r(0);
@@ -348,13 +460,13 @@ TEST_P(clustering_test, get_nearest_center) {
     y.num_values_.push_back(make_pair("c", -500000 - r.next_gaussian() * 100));
     y.num_values_.push_back(make_pair("d", -10000 - r.next_gaussian() * 50));
 
-    vector<datum> one;
-    one.push_back(x);
+    vector<core::clustering::indexed_point> one;
+    one.push_back(single_indexed_point(lexical_cast<string>(2*i), x));
     clustering_->push(one);
     one.clear();
 
-    vector<datum> two;
-    two.push_back(y);
+    vector<core::clustering::indexed_point> two;
+    two.push_back(single_indexed_point(lexical_cast<string>(2*i+1),y));
     clustering_->push(two);
     two.clear();
   }
@@ -481,13 +593,13 @@ fv_converter::datum create_datum_str(const string& key, const string& value) {
 
 TEST_P(clustering_with_idf_test, get_nearest_members) {
   jubatus::util::math::random::mtrand r(0);
-  vector<datum> one;
-  vector<datum> two;
+  vector<core::clustering::indexed_point> one;
+  vector<core::clustering::indexed_point> two;
 
   for (int i = 0; i < 200 ; ++i) {
     const string i_str = lexical_cast<string>(i);
-    one.push_back(create_datum_str("a" + i_str, "x y z " + i_str));
-    two.push_back(create_datum_str("a" + i_str, "y z w " + i_str));
+    one.push_back(single_indexed_point(lexical_cast<string>(i),create_datum_str("a" + i_str, "x y z " + i_str)));
+    two.push_back(single_indexed_point(lexical_cast<string>(i),create_datum_str("a" + i_str, "y z w " + i_str)));
   }
   clustering_->push(one);
   clustering_->push(two);


### PR DESCRIPTION
fix #317 

refactoring clustering API  below.
## add data structure
```
indexed_point 
  0: string  ID,
  1: datum point
```
ID indentify indivisual data. 

```
weighted_index
 0: double weight
 1: string ID
```

## modify API
```
bool push(0: list<indexed_point> points)
```
## add API
```
list<list<weighted_index>> get_core_members_light()
list<list<weighted_index>> get_nearest_members_light()
```
This API returns only IDs and Weights. It is easy to know which data includes cluster.

And change config value
```
 change compressor_ method value from {compressive_kmeans,compressive_gmm} to {compressive}.
 Because we can tell kmeans and gmm with method value.
```