### PR TITLE
fix convert binaries to pass the feature rule name

### DIFF
--- a/jubatus/core/fv_converter/datum_to_fv_converter.cpp
+++ b/jubatus/core/fv_converter/datum_to_fv_converter.cpp
@@ -422,7 +422,8 @@ class datum_to_fv_converter_impl {
       const std::string& value = binary_values[j].second;
       if (feature.matcher_->match(key)) {
         check_key(key);
-        feature.feature_func_->add_feature(key, value, ret_fv);
+        std::string k = key + "@" + feature.name_;
+        feature.feature_func_->add_feature(k, value, ret_fv);
       }
     }
   }

--- a/jubatus/core/fv_converter/datum_to_fv_converter_test.cpp
+++ b/jubatus/core/fv_converter/datum_to_fv_converter_test.cpp
@@ -304,7 +304,7 @@ TEST(datum_to_fv_converter, register_binary_rule) {
     EXPECT_EQ(1u, feature.size());
 
     std::vector<std::pair<std::string, float> > exp;
-    exp.push_back(std::make_pair("/bin", 4.));
+    exp.push_back(std::make_pair("/bin@len", 4.));
 
     std::sort(feature.begin(), feature.end());
     std::sort(exp.begin(), exp.end());


### PR DESCRIPTION
Currently, binary feature converter doesn't have any way to add rule name to the feature-key.
This pull-request modifies the method like other converters.  