### PR TITLE
add dbscan algorithm for clustering.

### DIFF
--- a/jubatus/core/clustering/clustering.cpp
+++ b/jubatus/core/clustering/clustering.cpp
@@ -43,14 +43,26 @@ clustering::clustering(
       method_(method),
       storage_() {
 
-  if (!(1 <= cfg.k)) {
-    throw JUBATUS_EXCEPTION(
-        common::invalid_parameter("1 <= k"));
-  }
+  if (method_ == "kmeans" || method_ == "gmm") {
+    if (!(1 <= cfg.k)) {
+      throw JUBATUS_EXCEPTION(
+          common::invalid_parameter("1 <= k"));
+    }
 
-  if (!(1 <= cfg.bucket_size)) {
-    throw JUBATUS_EXCEPTION(
-        common::invalid_parameter("1 <= bucket_size"));
+    if (!(1 <= cfg.bucket_size)) {
+      throw JUBATUS_EXCEPTION(
+          common::invalid_parameter("1 <= bucket_size"));
+    }
+  } else if (method_ == "dbscan") {
+    if (!(0.0 < cfg.eps)) {
+      throw JUBATUS_EXCEPTION(
+          common::invalid_parameter("0.0 < eps"));
+    }
+
+    if (!(1 <= cfg.min_core_point)) {
+      throw JUBATUS_EXCEPTION(
+          common::invalid_parameter("1 <= min_core_point"));
+    }
   }
 
   if (cfg.compressor_method != "simple") {

--- a/jubatus/core/clustering/clustering_config.hpp
+++ b/jubatus/core/clustering/clustering_config.hpp
@@ -36,7 +36,9 @@ struct clustering_config {
         compressed_bucket_size(200),
         forgetting_factor(2.0),
         forgetting_threshold(0.05),
-        seed(0) {
+        eps(2.0),
+        seed(0),
+        min_core_point(1) {
   }
 
   int k;
@@ -49,7 +51,9 @@ struct clustering_config {
   int compressed_bucket_size;
   double forgetting_factor;
   double forgetting_threshold;
+  double eps;
   int64_t seed;
+  int min_core_point;
 
   MSGPACK_DEFINE(
       k,
@@ -60,7 +64,9 @@ struct clustering_config {
       compressed_bucket_size,
       forgetting_factor,
       forgetting_threshold,
-      seed);
+      eps,
+      seed,
+      min_core_point);
 
   template<typename Ar>
   void serialize(Ar& ar) {
@@ -72,7 +78,9 @@ struct clustering_config {
         & JUBA_MEMBER(compressed_bucket_size)
         & JUBA_MEMBER(forgetting_factor)
         & JUBA_MEMBER(forgetting_threshold)
-        & JUBA_MEMBER(seed);
+        & JUBA_MEMBER(eps)
+        & JUBA_MEMBER(seed)
+        & JUBA_MEMBER(min_core_point);
   }
 };
 

--- a/jubatus/core/clustering/clustering_method_factory.cpp
+++ b/jubatus/core/clustering/clustering_method_factory.cpp
@@ -19,6 +19,7 @@
 #include <string>
 #include "../common/exception.hpp"
 #include "kmeans_clustering_method.hpp"
+#include "dbscan_clustering_method.hpp"
 #ifdef JUBATUS_USE_EIGEN
 #include "gmm_clustering_method.hpp"
 #endif
@@ -37,6 +38,9 @@ shared_ptr<clustering_method> clustering_method_factory::create(
   if (method == "kmeans") {
     return shared_ptr<clustering_method>(
         new kmeans_clustering_method(config.k, config.seed));
+  } else if (method == "dbscan") {
+    return shared_ptr<clustering_method>(
+        new dbscan_clustering_method(config.eps, config.min_core_point));
 #ifdef JUBATUS_USE_EIGEN
   } else if (method == "gmm") {
     return shared_ptr<clustering_method>(

--- a/jubatus/core/clustering/dbscan.cpp
+++ b/jubatus/core/clustering/dbscan.cpp
@@ -1,0 +1,123 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2013 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+#include "dbscan.hpp"
+
+#include <vector>
+#include "clustering.hpp"
+#include "util.hpp"
+#include "jubatus/util/lang/cast.h"
+#include "../common/exception.hpp"
+
+using std::vector;
+using jubatus::util::lang::lexical_cast;
+
+
+namespace jubatus {
+namespace core {
+namespace clustering {
+
+dbscan::dbscan(double eps, size_t min_core_point)
+    : eps_(eps),
+      min_core_point_(min_core_point) {
+}
+
+void dbscan::batch(const wplist& points) {
+  clusters_.clear();
+  point_states_.assign(lexical_cast<int>(points.size()), dbscan::UNCLASSIFIED);
+
+  for (size_t size = points.size(), i = 0; i < size; ++i) {
+    if (point_states_[i] != dbscan::UNCLASSIFIED) {
+      continue;
+    }
+    wplist cluster = dbscan::expand_cluster(i, points);
+
+    if (cluster.size() >= min_core_point_) {
+      clusters_.push_back(cluster);
+    }
+  }
+}
+
+std::vector<int> dbscan::get_point_states() const {
+  return point_states_;
+}
+
+std::vector<wplist> dbscan::get_clusters() const {
+  return clusters_;
+}
+
+void dbscan::set_eps(double eps) {
+  eps_ = eps;
+}
+
+// return cluster as wplist
+wplist dbscan::expand_cluster(const size_t idx, const wplist& points) {
+  wplist cluster;
+  vector<size_t> core = region_query(idx, points);
+
+  if (core.size() < min_core_point_) {
+    point_states_[idx] = NOISE;
+  } else {
+    point_states_[idx] = CLASSIFIED;
+    cluster.push_back(points[idx]);
+    do {
+      std::vector<size_t> added_core;
+      for (vector<size_t>::iterator it = core.begin(); it != core.end(); ++it) {
+        if (point_states_[*it] == CLASSIFIED) {
+          continue;
+        }
+        point_states_[*it] = CLASSIFIED;
+        cluster.push_back(points[*it]);
+
+        vector<size_t> expand_core = region_query((*it), points);
+
+        for (vector<size_t>::iterator expand_it = expand_core.begin();
+            expand_it != expand_core.end(); ++expand_it) {
+          if (expand_core.size() >= min_core_point_) {
+            if (point_states_[*expand_it] == CLASSIFIED) {
+              continue;
+            }
+            if (point_states_[*expand_it] == UNCLASSIFIED) {
+              // if point have not classified yet, the point push core.
+              added_core.push_back(*expand_it);
+            } else {
+              cluster.push_back(points[*expand_it]);
+              point_states_[*expand_it] = CLASSIFIED;
+            }
+          }
+        }
+      }
+      core = added_core;
+    } while (!core.empty());
+  }
+  return cluster;
+}
+
+std::vector<size_t> dbscan::region_query(
+    const size_t idx, const wplist& points) const {
+  std::vector<size_t> region;
+
+  for (wplist::const_iterator it = points.begin(); it != points.end(); ++it) {
+    if (dist((*it).data, points[idx].data) < eps_) {
+      region.push_back(std::distance(points.begin(), it));
+    }
+  }
+  return region;
+}
+
+}  // namespace clustering
+}  // namespace core
+}  // namespace jubatus

--- a/jubatus/core/clustering/dbscan.hpp
+++ b/jubatus/core/clustering/dbscan.hpp
@@ -1,0 +1,55 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2013 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+#ifndef JUBATUS_CORE_CLUSTERING_DBSCAN_HPP_
+#define JUBATUS_CORE_CLUSTERING_DBSCAN_HPP_
+
+#include <vector>
+#include "types.hpp"
+
+namespace jubatus {
+namespace core {
+namespace clustering {
+
+class dbscan {
+ public:
+  dbscan(double eps, size_t min_core_point);
+
+  void batch(const wplist& points);
+  std::vector<int> get_point_states() const;
+  std::vector<wplist> get_clusters() const;
+  void set_eps(double eps);
+
+ private:
+  wplist expand_cluster(const size_t idx, const wplist& points);
+  std::vector<size_t> region_query(
+      const size_t idx, const wplist& points) const;
+
+  double eps_;
+  size_t min_core_point_;
+  std::vector<int> point_states_;
+  std::vector<wplist> clusters_;
+
+  static const int UNCLASSIFIED = 0;
+  static const int CLASSIFIED = 1;
+  static const int NOISE = -1;
+};
+
+}  // namespace clustering
+}  // namespace core
+}  // namesapce jubatus
+
+#endif  // JUBATUS_CORE_CLUSTERING_DBSCAN_HPP_

--- a/jubatus/core/clustering/dbscan_clustering_method.cpp
+++ b/jubatus/core/clustering/dbscan_clustering_method.cpp
@@ -1,0 +1,86 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2013 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+#include "dbscan_clustering_method.hpp"
+
+#include <vector>
+#include "../common/exception.hpp"
+#include "clustering.hpp"
+#include "util.hpp"
+
+using std::pair;
+using std::vector;
+
+namespace jubatus {
+namespace core {
+namespace clustering {
+
+dbscan_clustering_method::dbscan_clustering_method(
+    double eps, size_t min_core_point)
+    : eps_(eps),
+      min_core_point_(min_core_point),
+      dbscan_(eps, min_core_point) {
+}
+
+dbscan_clustering_method::~dbscan_clustering_method() {
+}
+
+void dbscan_clustering_method::batch_update(wplist points) {
+  if (points.empty()) {
+    *this = dbscan_clustering_method(eps_, min_core_point_);
+    return;
+  }
+  dbscan_.batch(points);
+}
+
+void dbscan_clustering_method::online_update(wplist points) {
+}
+
+std::vector<common::sfv_t> dbscan_clustering_method::get_k_center() const {
+  throw JUBATUS_EXCEPTION(core::common::unsupported_method("get_k_center"));
+}
+
+int64_t dbscan_clustering_method::get_nearest_center_index(
+    const common::sfv_t& point) const {
+  throw JUBATUS_EXCEPTION(
+      core::common::unsupported_method("get_nearest_center_index"));
+}
+
+common::sfv_t dbscan_clustering_method::get_nearest_center(
+    const common::sfv_t& point) const {
+  throw JUBATUS_EXCEPTION(
+      core::common::unsupported_method("get_nearest_center"));
+}
+
+wplist dbscan_clustering_method::get_cluster(
+    const size_t cluster_id,
+    const wplist& points) const {
+  return get_clusters(points)[cluster_id];
+}
+
+std::vector<wplist> dbscan_clustering_method::get_clusters(
+    const wplist& points) const {
+  std::vector<wplist> clusters = dbscan_.get_clusters();
+  if (clusters.empty()) {
+    throw JUBATUS_EXCEPTION(not_performed());
+  }
+  return clusters;
+}
+
+}  // namespace clustering
+}  // namespace core
+}  // namespace jubatus
+

--- a/jubatus/core/clustering/dbscan_clustering_method.hpp
+++ b/jubatus/core/clustering/dbscan_clustering_method.hpp
@@ -1,0 +1,56 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2013 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+#ifndef JUBATUS_CORE_CLUSTERING_DBSCAN_CLUSTERING_METHOD_HPP_
+#define JUBATUS_CORE_CLUSTERING_DBSCAN_CLUSTERING_METHOD_HPP_
+
+#include <vector>
+#include "../common/type.hpp"
+#include "clustering_method.hpp"
+#include "dbscan.hpp"
+
+namespace jubatus {
+namespace core {
+namespace clustering {
+
+class dbscan_clustering_method : public clustering_method {
+ public:
+  dbscan_clustering_method(double eps, size_t min_core_point);
+  ~dbscan_clustering_method();
+
+  void batch_update(wplist points);
+  void online_update(wplist points);
+  std::vector<common::sfv_t> get_k_center() const;
+  common::sfv_t get_nearest_center(const common::sfv_t& point) const;
+  int64_t get_nearest_center_index(const common::sfv_t& point) const;
+  wplist get_cluster(size_t cluster_id, const wplist& points) const;
+  std::vector<wplist> get_clusters(const wplist& points) const;
+
+ private:
+  void initialize_centers(wplist& points);
+  void do_batch_update(wplist& points);
+
+  std::vector<common::sfv_t> kcenters_;
+  double eps_;
+  size_t min_core_point_;
+  dbscan dbscan_;
+};
+
+}  // namespace clustering
+}  // namespace core
+}  // namespace jubatus
+
+#endif  // JUBATUS_CORE_CLUSTERING_DBSCAN_CLUSTERING_METHOD_HPP_

--- a/jubatus/core/clustering/dbscan_test.cpp
+++ b/jubatus/core/clustering/dbscan_test.cpp
@@ -1,0 +1,212 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2014 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+#include <vector>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "jubatus/util/lang/scoped_ptr.h"
+#include "jubatus/util/math/random.h"
+#include "clustering.hpp"
+#include "dbscan.hpp"
+#include "../common/type.hpp"
+#include "types.hpp"
+#include "jubatus/util/lang/cast.h"
+#include "../common/exception.hpp"
+
+using jubatus::util::lang::lexical_cast;
+using jubatus::util::lang::shared_ptr;
+
+namespace jubatus {
+namespace core {
+namespace clustering {
+
+class dbscan_test : public ::testing::Test {
+ protected:
+  static const double eps = 4.0;
+  static const size_t min_core_point = 2;
+
+  virtual void SetUp() {
+    dbscan_.reset(new dbscan(eps, min_core_point));
+  }
+
+  virtual void TearDown() {
+    dbscan_.reset();
+  }
+
+  jubatus::util::lang::scoped_ptr<dbscan> dbscan_;
+
+  void do_batch() {
+    common::sfv_t p1;
+    p1.push_back(std::make_pair("x", 1));
+    p1.push_back(std::make_pair("y", 1));
+    weighted_point wp1;
+    wp1.id = "0";
+    wp1.weight = 1.0;
+    wp1.data = p1;
+
+    common::sfv_t p2;
+    p2.push_back(std::make_pair("x", 2));
+    p2.push_back(std::make_pair("y", 2));
+    weighted_point wp2;
+    wp2.id = "1";
+    wp2.weight = 1.0;
+    wp2.data = p2;
+
+    common::sfv_t p3;
+    p3.push_back(std::make_pair("x", 4));
+    p3.push_back(std::make_pair("y", 4));
+    weighted_point wp3;
+    wp3.id = "2";
+    wp3.weight = 1.0;
+    wp3.data = p3;
+
+    common::sfv_t p4;
+    p4.push_back(std::make_pair("x", 5));
+    p4.push_back(std::make_pair("y", 5));
+    weighted_point wp4;
+    wp4.id = "3";
+    wp4.weight = 1.0;
+    wp4.data = p4;
+
+    common::sfv_t p5;
+    p5.push_back(std::make_pair("x", 50));
+    p5.push_back(std::make_pair("y", 50));
+    weighted_point wp5;
+    wp5.id = "4";
+    wp5.weight = 1.0;
+    wp5.data = p5;
+
+    common::sfv_t p6;
+    p6.push_back(std::make_pair("x", 51));
+    p6.push_back(std::make_pair("y", 51));
+    weighted_point wp6;
+    wp6.id = "5";
+    wp6.weight = 1.0;
+    wp6.data = p6;
+
+    common::sfv_t p7;
+    p7.push_back(std::make_pair("x", 100));
+    p7.push_back(std::make_pair("y", 100));
+    weighted_point wp7;
+    wp7.id = "6";
+    wp7.weight = 1.0;
+    wp7.data = p7;
+
+    wplist points;
+    points.push_back(wp1);
+    points.push_back(wp2);
+    points.push_back(wp3);
+    points.push_back(wp4);
+    points.push_back(wp5);
+    points.push_back(wp6);
+    points.push_back(wp7);
+
+    dbscan_->batch(points);
+  }
+
+  void do_two_clustering() {
+    dbscan_->set_eps(100.0);
+    jubatus::util::math::random::mtrand r(0);
+    int data_num = 50;
+    wplist points;
+
+    for (int i = 0; i < data_num; ++i) {
+      common::sfv_t x, y;
+      weighted_point wp;
+
+      x.push_back(std::make_pair("a", 100 + r.next_gaussian() * 20));
+      x.push_back(std::make_pair("b", 100 + r.next_gaussian() * 40));
+
+      wp.id = lexical_cast<std::string>(2*i);
+      wp.weight = 1.0;
+      wp.data = x;
+
+      points.push_back(wp);
+
+      y.push_back(std::make_pair("c", -1000 - r.next_gaussian() * 20));
+      y.push_back(std::make_pair("d", -1000 - r.next_gaussian() * 40));
+
+      wp.id = lexical_cast<std::string>(2*i+1);
+      wp.weight = 1.0;
+      wp.data = y;
+
+      points.push_back(wp);
+    }
+    dbscan_->batch(points);
+  }
+};
+
+TEST_F(dbscan_test, batch) {
+  do_batch();
+
+  std::vector<int> point_states = dbscan_->get_point_states();
+  // std::cout << "poinst states:" << point_states.size() << " [";
+  // for (std::vector<int>::iterator it = point_states.begin();
+  //      it != point_states.end(); ++it) {
+  //   std::cout << *it << " ";
+  // }
+  // std::cout << "]" << std::endl;
+
+  std::vector<wplist> clusters = dbscan_->get_clusters();
+  // for (std::vector<wplist>::iterator it = clusters.begin();
+  //      it != clusters.end(); ++it) {
+    // std::cout << "[ ";
+    // for (wplist::iterator wit = (*it).begin(); wit != (*it).end(); ++wit) {
+    //   std::cout << (*wit).id << " ";
+    // }
+    // std::cout << "]" << std::endl;
+  // }
+
+  ASSERT_EQ(lexical_cast<size_t>(2), clusters.size());
+  ASSERT_EQ(lexical_cast<size_t>(4), clusters[0].size());
+  ASSERT_EQ(lexical_cast<size_t>(2), clusters[1].size());
+}
+
+TEST_F(dbscan_test, devide_two_cluster) {
+  do_two_clustering();
+
+  std::vector<int> point_states = dbscan_->get_point_states();
+  std::cout << "poinst states:" << point_states.size() << " [";
+  for (std::vector<int>::iterator it = point_states.begin();
+       it != point_states.end(); ++it) {
+    std::cout << *it << " ";
+  }
+  std::cout << "]" << std::endl;
+
+  std::vector<wplist> clusters = dbscan_->get_clusters();
+  for (std::vector<wplist>::iterator it = clusters.begin();
+       it != clusters.end(); ++it) {
+    std::cout << "[ ";
+    for (wplist::iterator wit = (*it).begin(); wit != (*it).end(); ++wit) {
+      std::cout << (*wit).id << " ";
+    }
+    std::cout << "]" << std::endl;
+  }
+
+  size_t cluster_num(2);
+  size_t cluster1_num(50);
+  size_t cluster2_num(50);
+  ASSERT_EQ(cluster_num, clusters.size());
+  ASSERT_EQ(cluster1_num, clusters[0].size());
+  ASSERT_EQ(cluster2_num, clusters[1].size());
+}
+
+
+}  // namespace clustering
+}  // namespace core
+}  // namespace jubatus

--- a/jubatus/core/clustering/storage_factory.cpp
+++ b/jubatus/core/clustering/storage_factory.cpp
@@ -47,11 +47,20 @@ jubatus::util::lang::shared_ptr<storage> storage_factory::create(
       throw JUBATUS_EXCEPTION(
           common::unsupported_method(config.compressor_method));
     }
+  } else if (method == "dbscan") {
+    if (config.compressor_method == "simple") {
+      simple_storage *s = new simple_storage(name, config);
+      ret.reset(s);
+    } else {
+      throw JUBATUS_EXCEPTION(
+          common::unsupported_method(config.compressor_method));
+    }
+#ifdef JUBATUS_USE_EIGEN
   } else if (method == "gmm") {
     if (config.compressor_method == "simple") {
         simple_storage *s = new simple_storage(name, config);
         ret.reset(s);
-#ifdef JUBATUS_USE_EIGEN
+
     } else if (config.compressor_method == "compressive") {
       compressive_storage *s = new compressive_storage(name, config);
       s->set_compressor(jubatus::util::lang::shared_ptr<compressor::compressor>(

--- a/jubatus/core/clustering/types.hpp
+++ b/jubatus/core/clustering/types.hpp
@@ -53,6 +53,12 @@ struct indexed_point {
   MSGPACK_DEFINE(id, point);
   std::string id;
   fv_converter::datum point;
+  indexed_point() {
+  }
+  indexed_point(const std::string& id,
+      const jubatus::core::fv_converter::datum& point)
+    : id(id), point(point) {
+  }
 };
 
 inline void swap(weighted_point& p1, weighted_point& p2) {

--- a/jubatus/core/clustering/wscript
+++ b/jubatus/core/clustering/wscript
@@ -14,9 +14,11 @@ def build(bld):
     'storage_factory.cpp',
     'kmeans_compressor.cpp',
     'kmeans_clustering_method.cpp',
+    'dbscan_clustering_method.cpp',
     'clustering_method_factory.cpp',
     'discrete_distribution.cpp',
-    'util.cpp'
+    'util.cpp',
+    'dbscan.cpp',
   ]
   headers = [
     'clustering_config.hpp',
@@ -33,12 +35,14 @@ def build(bld):
     'gmm.hpp',
     'gmm_types.hpp',
     'kmeans_clustering_method.hpp',
+    'dbscan_clustering_method.hpp',
     'kmeans_compressor.hpp',
     'simple_storage.hpp',
     'storage_factory.hpp',
     'storage.hpp',
     'types.hpp',
     'util.hpp',
+    'dbscan.hpp',
   ]
   if bld.env.USE_EIGEN:
     source += [
@@ -61,6 +65,7 @@ def build(bld):
     'model_test.cpp',
     'storage_test.cpp',
     'util_test.cpp',
+    'dbscan_test.cpp'
   ]
   if bld.env.USE_EIGEN:
     test_cases += [

--- a/jubatus/core/driver/clustering.cpp
+++ b/jubatus/core/driver/clustering.cpp
@@ -16,6 +16,7 @@
 
 #include "clustering.hpp"
 
+#include <string>
 #include <algorithm>
 #include <utility>
 #include <vector>

--- a/jubatus/core/driver/clustering.hpp
+++ b/jubatus/core/driver/clustering.hpp
@@ -17,6 +17,7 @@
 #ifndef JUBATUS_CORE_DRIVER_CLUSTERING_HPP_
 #define JUBATUS_CORE_DRIVER_CLUSTERING_HPP_
 
+#include <string>
 #include <utility>
 #include <vector>
 #include "jubatus/util/lang/shared_ptr.h"
@@ -84,7 +85,8 @@ class clustering : public driver_base {
       const std::vector<common::sfv_t>& src) const;
   std::vector<core::clustering::weighted_point> to_weighted_point_vector(
       const std::vector<fv_converter::datum>& src);
-  std::vector<core::clustering::weighted_point> to_weighted_indexed_point_vector(
+  std::vector<core::clustering::weighted_point>
+  to_weighted_indexed_point_vector(
       const std::vector<core::clustering::indexed_point>& src);
   core::clustering::cluster_unit to_weighted_datum_vector(
       const std::vector<core::clustering::weighted_point>& src) const;

--- a/jubatus/core/driver/clustering_test.cpp
+++ b/jubatus/core/driver/clustering_test.cpp
@@ -76,13 +76,17 @@ class clustering_test
     conf_.bucket_length = 2;
     conf_.forgetting_factor = 0.0;
     conf_.forgetting_threshold = 0.5;
+    conf_.eps = 100.0;
+    conf_.min_core_point = 2;
     clustering_ = create_driver();
+    method_ = param.second;
   }
   void TearDown() {
     clustering_.reset();
   }
   shared_ptr<driver::clustering> clustering_;
   clustering_config conf_;
+  string method_;
 };
 
 namespace {  // testing util
@@ -103,7 +107,8 @@ TEST_P(clustering_test, get_revision) {
   const int num = conf_.bucket_size * 10;
   for (int i = 0; i < num; ++i) {
     vector<core::clustering::indexed_point> points;
-    points.push_back(single_indexed_point(lexical_cast<string>(i),single_datum("a", 1)));
+    points.push_back(single_indexed_point(
+        lexical_cast<string>(i), single_datum("a", 1)));
     clustering_->push(points);
   }
   std::size_t expected = num / conf_.bucket_size;
@@ -114,8 +119,10 @@ TEST_P(clustering_test, push) {
   for (int j = 0; j < conf_.bucket_size / 5; ++j) {
     vector<core::clustering::indexed_point> points;
     for (int i = 0; i < 100; i += 5) {
-      points.push_back(single_indexed_point(lexical_cast<string>(i),single_datum("a", i * 2)));
-      points.push_back(single_indexed_point(lexical_cast<string>(i),single_datum("a", i * 2)));
+      points.push_back(single_indexed_point(
+          lexical_cast<string>(i), single_datum("a", i * 2)));
+      points.push_back(single_indexed_point(
+          lexical_cast<string>(i), single_datum("a", i * 2)));
     }
     clustering_->push(points);
   }
@@ -130,7 +137,7 @@ TEST_P(clustering_test, push_indexed_point) {
     points.push_back(single_indexed_point(lexical_cast<string>(i), d));
   }
   clustering_->push(points);
-  std::size_t expected = num / skip / conf_.bucket_size ;
+  std::size_t expected = num / skip / conf_.bucket_size;
   ASSERT_EQ(expected, clustering_->get_revision());
 }
 
@@ -138,10 +145,11 @@ TEST_P(clustering_test, save_load) {
   {
     core::fv_converter::datum d;
     vector<core::clustering::indexed_point> points;
-    points.push_back(single_indexed_point(lexical_cast<string>(1),single_datum("a", 1)));
+    points.push_back(single_indexed_point(
+        lexical_cast<string>(1), single_datum("a", 1)));
     clustering_->push(points);
   }
-  
+
   // save to a buffer
   msgpack::sbuffer sbuf;
   framework::stream_writer<msgpack::sbuffer> st(sbuf);
@@ -163,7 +171,8 @@ TEST_P(clustering_test, clear) {
   const int num = conf_.bucket_size * 10;
   for (int i = 0; i < num; ++i) {
     vector<core::clustering::indexed_point> points;
-    points.push_back(single_indexed_point(lexical_cast<string>(i),single_datum("a", 1)));
+    points.push_back(single_indexed_point(
+        lexical_cast<string>(i), single_datum("a", 1)));
     clustering_->push(points);
   }
 
@@ -172,10 +181,16 @@ TEST_P(clustering_test, clear) {
   ASSERT_THROW(
       clustering_->get_core_members(),
       core::clustering::not_performed);
+
   ASSERT_EQ(0u, clustering_->get_revision());
 }
 
 TEST_P(clustering_test, get_k_center) {
+  if (method_ == "dbscan") {
+      ASSERT_THROW(clustering_->get_k_center(), common::unsupported_method);
+      return;
+    }
+
   jubatus::util::math::random::mtrand r(0);
 
   for (int j = 0; j < conf_.bucket_size; ++j) {
@@ -186,12 +201,12 @@ TEST_P(clustering_test, get_k_center) {
     b.num_values_.push_back(make_pair("d", 250000 + r.next_gaussian() * 500));
 
     vector<core::clustering::indexed_point> one;
-    one.push_back(single_indexed_point("1",a));
+    one.push_back(single_indexed_point("1", a));
     clustering_->push(one);
     one.clear();
 
     vector<core::clustering::indexed_point> two;
-    two.push_back(single_indexed_point("2",b));
+    two.push_back(single_indexed_point("2", b));
     clustering_->push(two);
     two.clear();
   }
@@ -201,7 +216,7 @@ TEST_P(clustering_test, get_k_center) {
     vector<datum> result = clustering_->get_k_center();
     ASSERT_EQ(std::size_t(conf_.k), result.size());
     ASSERT_LT(1U, result[0].num_values_.size());
-    
+
     // two center should be far about sqrt(100^2 + 200^2 + 5000^2 + 250000^2)
     double squared_diff = 0;
     std::vector<map<string, double> > centers;
@@ -227,12 +242,17 @@ TEST_P(clustering_test, get_k_center) {
 }
 
 TEST_P(clustering_test, integer_center) {
+  if (method_ == "dbscan") {  //  dbscan does not have center. so pass this test
+    return;
+  }
+
   jubatus::util::math::random::mtrand r(0);
   const int quantity = conf_.bucket_size * 5;
   std::vector<core::clustering::indexed_point> data(quantity);
 
   for (int i = 0; i < quantity ; ++i) {
-    data[i].point.num_values_.push_back(make_pair("x", 100 + r.next_int(-10, 10)));
+    data[i].point.num_values_.push_back(
+        make_pair("x", 100 + r.next_int(-10, 10)));
     data[i].id = lexical_cast<string>(i);
   }
 
@@ -240,8 +260,8 @@ TEST_P(clustering_test, integer_center) {
   const std::vector<fv_converter::datum> centers = clustering_->get_k_center();
 
   ASSERT_EQ(std::size_t(conf_.k), centers.size());
-  //debug out
-  // for (size_t i = 0; i < centers.size(); ++i) {
+  //  debug out
+  //  for (size_t i = 0; i < centers.size(); ++i) {
   //   std::cout << i << " :[";
   //   for (size_t j = 0; j < centers[i].num_values_.size(); ++j) {
   //     std::cout
@@ -276,7 +296,6 @@ struct check_point_compare {
   }
 };
 
-
 TEST_P(clustering_test, get_nearest_members) {
   jubatus::util::math::random::mtrand r(0);
 
@@ -307,8 +326,12 @@ TEST_P(clustering_test, get_nearest_members) {
   clustering_->do_clustering();
 
   {
-    vector<datum> result = clustering_->get_k_center();
-    ASSERT_EQ(std::size_t(conf_.k), result.size());
+    if (method_ == "dbscan") {
+      ASSERT_THROW(clustering_->get_k_center(), common::unsupported_method);
+    } else {
+      vector<datum> result = clustering_->get_k_center();
+      ASSERT_EQ(std::size_t(conf_.k), result.size());
+    }
   }
 
   set<check_points, check_point_compare>::const_iterator it;
@@ -316,6 +339,13 @@ TEST_P(clustering_test, get_nearest_members) {
     datum x;
     x.num_values_.push_back(make_pair("a", it->a));
     x.num_values_.push_back(make_pair("b", it->b));
+
+    if (method_ == "dbscan") {
+      ASSERT_THROW(clustering_->
+                   get_nearest_members(x), common::unsupported_method);
+      return;
+    }
+
     core::clustering::cluster_unit result =
         clustering_->get_nearest_members(x);
 
@@ -368,28 +398,37 @@ TEST_P(clustering_test, get_nearest_members_light) {
     x.num_values_.push_back(make_pair("b", b));
     y.num_values_.push_back(make_pair("c", -5000 - r.next_gaussian() * 100));
     y.num_values_.push_back(make_pair("d", -1000 - r.next_gaussian() * 50));
-    
+
     vector<core::clustering::indexed_point> one;
     one.push_back(single_indexed_point(lexical_cast<string>(2*i), x));
     clustering_->push(one);
     one.clear();
 
     vector<core::clustering::indexed_point> two;
-    two.push_back(single_indexed_point(lexical_cast<string>(2*i+1),y));
+    two.push_back(single_indexed_point(lexical_cast<string>(2*i+1), y));
     clustering_->push(two);
     two.clear();
   }
 
   clustering_->do_clustering();
   {
-    vector<datum> result = clustering_->get_k_center();
-    ASSERT_EQ(std::size_t(conf_.k), result.size());
-    std::cout << "cluster size : " << result.size() << std::endl;
+    if (method_ == "dbscan") {
+      ASSERT_THROW(clustering_->get_k_center(), common::unsupported_method);
+    } else {
+      vector<datum> result = clustering_->get_k_center();
+      ASSERT_EQ(std::size_t(conf_.k), result.size());
+    }
   }
 
   datum x;
   x.num_values_.push_back(make_pair("a", 100));
   x.num_values_.push_back(make_pair("b", 1000));
+  if (method_ == "dbscan") {
+    ASSERT_THROW(clustering_->
+                 get_nearest_members_light(x), common::unsupported_method);
+    return;
+  }
+
   core::clustering::index_cluster_unit result =
       clustering_->get_nearest_members_light(x);
   // std::cout << " ["; //debug out
@@ -405,14 +444,14 @@ TEST_P(clustering_test, get_nearest_members_light) {
 TEST_P(clustering_test, get_core_members_light) {
   jubatus::util::math::random::mtrand r(0);
   int data_num = 50;
-  
+
   for (int i = 0; i < data_num; ++i) {
     datum x, y;
 
     x.num_values_.push_back(make_pair("a", 100 + r.next_gaussian() * 20));
-    x.num_values_.push_back(make_pair("b", 1000 + r.next_gaussian() * 400));
-    y.num_values_.push_back(make_pair("c", -5000 - r.next_gaussian() * 100));
-    y.num_values_.push_back(make_pair("d", -1000 - r.next_gaussian() * 50));
+    x.num_values_.push_back(make_pair("b", 100 + r.next_gaussian() * 40));
+    y.num_values_.push_back(make_pair("c", -1000 - r.next_gaussian() * 20));
+    y.num_values_.push_back(make_pair("d", -1000 - r.next_gaussian() * 40));
 
     vector<core::clustering::indexed_point> one;
     one.push_back(single_indexed_point(lexical_cast<string>(2*i), x));
@@ -420,34 +459,33 @@ TEST_P(clustering_test, get_core_members_light) {
     one.clear();
 
     vector<core::clustering::indexed_point> two;
-    two.push_back(single_indexed_point(lexical_cast<string>(2*i+1),y));
+    two.push_back(single_indexed_point(lexical_cast<string>(2*i+1), y));
     clustering_->push(two);
     two.clear();
   }
-  
+
   clustering_->do_clustering();
 
   core::clustering::index_cluster_set result =
       clustering_->get_core_members_light();
+  for (size_t i = 0; i < result.size(); ++i) {
+    std::cout << i << " :[";  //  debug out
+    if (lexical_cast<int>(result[i][0].second)%2 == 0) {
+      for (size_t j = 0; j < result[i].size(); ++j)  {
+        ASSERT_EQ(0, lexical_cast<int>(result[i][0].second)%2);
+        std::cout << result[i][j].second << ", ";
+      }
+         } else {
+      for (size_t j = 0; j < result[i].size(); ++j)  {
+        ASSERT_EQ(1, lexical_cast<int>(result[i][0].second)%2);
+        std::cout << result[i][j].second << ", ";
+      }
+    }
+    std::cout << "]" << std::endl;
+  }
   ASSERT_EQ(std::size_t(conf_.k), result.size());
   ASSERT_EQ(std::size_t(data_num), result[0].size());
   ASSERT_EQ(std::size_t(data_num), result[1].size());
-  
-  for (size_t i = 0; i < result.size(); ++i) {
-    // std::cout << i << " :["; //debug out
-    if (lexical_cast<int>(result[i][0].second)%2 == 0) {
-      for (size_t j = 1; j < result[i].size(); ++j)  {
-        ASSERT_EQ(0, lexical_cast<int>(result[i][0].second)%2);
-        // std::cout << result[i][j].second << ", ";
-      }
-    } else {
-      for (size_t j = 1; j < result[i].size(); ++j)  {
-        ASSERT_EQ(1, lexical_cast<int>(result[i][0].second)%2);
-        // std::cout << result[i][j].second << ", ";
-      }
-    }
-    // std::cout << "]" << std::endl;
-  }
 }
 
 TEST_P(clustering_test, get_nearest_center) {
@@ -466,7 +504,7 @@ TEST_P(clustering_test, get_nearest_center) {
     one.clear();
 
     vector<core::clustering::indexed_point> two;
-    two.push_back(single_indexed_point(lexical_cast<string>(2*i+1),y));
+    two.push_back(single_indexed_point(lexical_cast<string>(2*i+1), y));
     clustering_->push(two);
     two.clear();
   }
@@ -474,6 +512,10 @@ TEST_P(clustering_test, get_nearest_center) {
   clustering_->do_clustering();
 
   {
+    if (method_ == "dbscan") {
+      ASSERT_THROW(clustering_->get_k_center(), common::unsupported_method);
+      return;
+    }
     vector<datum> result = clustering_->get_k_center();
     ASSERT_EQ(std::size_t(conf_.k), result.size());
   }
@@ -485,6 +527,7 @@ TEST_P(clustering_test, get_nearest_center) {
       x.num_values_.push_back(make_pair("b", 1000 + r.next_gaussian() * 400));
       datum expect_near_x = clustering_->get_nearest_center(x);
       const vector<pair<string, double> >& result = expect_near_x.num_values_;
+
       map<string, double> point;
       for (size_t j = 0; j < result.size(); ++j) {
         point.insert(result[j]);
@@ -542,6 +585,7 @@ vector<pair<string, string> > parameter_list() {
   vector<pair<string, string> > ret;
   ret.push_back(make_pair("simple", "kmeans"));
   ret.push_back(make_pair("compressive", "kmeans"));
+  ret.push_back(make_pair("simple", "dbscan"));
 #ifdef JUBATUS_USE_EIGEN
   ret.push_back(make_pair("simple", "gmm"));
   ret.push_back(make_pair("compressive", "gmm"));
@@ -578,11 +622,13 @@ class clustering_with_idf_test
     conf.bicriteria_base_size = 5;
     conf.compressed_bucket_size = 10;
     clustering_ = create_driver();
+    method_ = param.second;
   }
   void TearDown() {
     clustering_.reset();
   }
   shared_ptr<driver::clustering> clustering_;
+  string method_;
 };
 
 fv_converter::datum create_datum_str(const string& key, const string& value) {
@@ -598,8 +644,12 @@ TEST_P(clustering_with_idf_test, get_nearest_members) {
 
   for (int i = 0; i < 200 ; ++i) {
     const string i_str = lexical_cast<string>(i);
-    one.push_back(single_indexed_point(lexical_cast<string>(i),create_datum_str("a" + i_str, "x y z " + i_str)));
-    two.push_back(single_indexed_point(lexical_cast<string>(i),create_datum_str("a" + i_str, "y z w " + i_str)));
+    one.push_back(single_indexed_point(
+        lexical_cast<string>(i),
+        create_datum_str("a" + i_str, "x y z " + i_str)));
+    two.push_back(single_indexed_point(
+        lexical_cast<string>(i),
+        create_datum_str("a" + i_str, "y z w " + i_str)));
   }
   clustering_->push(one);
   clustering_->push(two);
@@ -607,6 +657,10 @@ TEST_P(clustering_with_idf_test, get_nearest_members) {
   clustering_->do_clustering();
 
   {
+    if (method_ == "dbscan") {
+      ASSERT_THROW(clustering_->get_k_center(), common::unsupported_method);
+      return;
+    }
     vector<datum> result = clustering_->get_k_center();
     ASSERT_EQ(2u, result.size());
   }


### PR DESCRIPTION
fix #330 

add dbscan algorithm for jubaclustering.

dbscan algorithm has two parameter eps and min_core_point.
It does not need k parameter, because it does not calculate center point of the cluster.

This algorithm does not support (throw unsupported_method exception)
- get_k_center
- get_nearest_center
- get_nearest_members_light