### PR TITLE
fix ignore_kth_same_point_ cannot be set to false

### DIFF
--- a/jubatus/core/anomaly/lof_storage.cpp
+++ b/jubatus/core/anomaly/lof_storage.cpp
@@ -82,7 +82,8 @@ lof_storage::lof_storage(
     shared_ptr<recommender::recommender_base> nn_engine)
     : neighbor_num_(config.nearest_neighbor_num),
       reverse_nn_num_(config.reverse_nearest_neighbor_num),
-      ignore_kth_same_point_(config.ignore_kth_same_point),
+      ignore_kth_same_point_(
+          config.ignore_kth_same_point && *config.ignore_kth_same_point),
       nn_engine_(nn_engine) {
 }
 


### PR DESCRIPTION
In ``lof`` algorithm of Anomaly engine, when config is set to:

1. "ignore_kth_same_point": true  => behaves as `true`
2. "ignore_kth_same_point": false  => behaves as `true`, which is not expected
3. "ignore_kth_same_point" is not defined => behaves as `false`

This PR fixes the case 2.