### PR TITLE
Use gold linker instead of bfd to avoid FMV dynamic loading issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,9 @@ matrix:
     - env:
       - DIST=ubuntu
       - VERSION=14.04
-# Bug: https://bugs.launchpad.net/ubuntu/+source/gcc-5/+bug/1568899
-#    - env:
-#      - DIST=ubuntu
-#      - VERSION=16.04 # gcc 5.3 (enabled function multiversioning)
+    - env:
+      - DIST=ubuntu
+      - VERSION=16.04 # gcc 5.3 (enabled function multiversioning)
 
 before_install:
   - docker pull ${DIST}:${VERSION}

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ install:
   - if [ "$DIST" == "ubuntu" ]; then
       docker exec test apt-get update;
       docker exec test apt-get -qq install lsb-release autoconf automake make g++ python2.7 wget tar bzip2 libmsgpack-dev;
-      docker exec test bash -c "wget --no-check-certificate https://github.com/kkos/oniguruma/releases/download/v5.9.6/onig-5.9.6.tar.gz && tar xvf onig-5.9.6.tar.gz && cd onig-5.9.6 && ./configure && make && make install && ldconfig";
+      docker exec test bash -c "wget --no-check-certificate https://github.com/kkos/oniguruma/releases/download/v5.9.6/onig-5.9.6.tar.gz && tar xvf onig-5.9.6.tar.gz && cd onig-5.9.6 && ./configure --prefix=/usr && make && make install && ldconfig";
       if [ "$VERSION" != "12.04" ]; then
         docker exec test ln -sf /usr/bin/python2.7 /usr/bin/python;
       fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,10 +65,11 @@ before_script:
   - docker exec -t test bash -ic "g++ --version"
 
 script:
-  - docker exec -t test bash -ic "./waf configure"
+  - docker exec -t test bash -ic "./waf configure --prefix=/usr"
   - docker exec -t test bash -ic "./waf build --checkall"
   - docker exec -t test bash -ic "./waf cpplint"
   - if [ -n "$SCL" ]; then docker exec test ./waf build --checkall; fi
+  - docker exec -t test bash -ic "./waf install; ldconfig; python -c 'import ctypes; ctypes.cdll.LoadLibrary(\"libjubatus_core.so\")'"
 
 branches:
   only:

--- a/wscript
+++ b/wscript
@@ -120,6 +120,8 @@ int main() { test(); }
   if not func_multiver_enabled:
     sse2_test_code = '#ifdef __SSE2__\nint main() {}\n#else\n#error\n#endif'
     conf.check_cxx(fragment=sse2_test_code, msg='Checking for sse2', mandatory=False)
+  if func_multiver_enabled and env.COMPILER_CXX == 'g++' and int(ver[0]) < 6:
+    conf.env.append_unique('LINKFLAGS', '-fuse-ld=gold')
 
   conf.recurse(subdirs)
 

--- a/wscript
+++ b/wscript
@@ -140,7 +140,13 @@ def build(bld):
   bld.recurse(subdirs)
 
   # core
-  bld.shlib(source=list(set(bld.core_sources)), target='jubatus_core', use=list(set(bld.core_use)), vnum = ABI_VERSION)
+  use_list = list(set(bld.core_use))
+  if bld.env.COMPILER_CXX == 'g++' and int(bld.env.CC_VERSION[0]) < 6:
+    # workaround
+    # https://bugs.launchpad.net/ubuntu/+source/gcc-5/+bug/1568899
+    use_list.append('GCC_WORKAROUND')
+    bld.env.LIB_GCC_WORKAROUND = ['gcc_s', 'gcc']
+  bld.shlib(source=list(set(bld.core_sources)), target='jubatus_core', use=use_list, vnum = ABI_VERSION)
   bld.install_files('${PREFIX}/include/', list(set(bld.core_headers)), relative_trick=True)
 
 


### PR DESCRIPTION
depends: #345 #346 

FMV有効時にいくつかの環境に置いてdlopen時にSEGVするのを回避するために
ld.bfd の代わりに ld.gold を利用するようにしました．
gcc6以降(Ubuntu 16.10)はbfdでも問題ない様なのでFMV有効かつgcc6未満を対称にしてます