### PR TITLE
Add distance weight option to nn regression

### DIFF
--- a/jubatus/core/driver/regression_test.cpp
+++ b/jubatus/core/driver/regression_test.cpp
@@ -98,6 +98,7 @@ shared_ptr<core::regression::regression_base> make_nn_regression() {
   js["parameter"] = json(new json_object);
   js["parameter"]["hash_num"] = to_json(8);
   js["nearest_neighbor_num"] = to_json(5);
+  js["weight"] = to_json(std::string("distance"));
   common::jsonconfig::config param(js);
   core::regression::nearest_neighbor_regression::config conf
     = config_cast_check<core::regression::nearest_neighbor_regression::config>(
@@ -109,14 +110,21 @@ shared_ptr<core::regression::regression_base> make_nn_regression() {
   shared_ptr<core::regression::regression_base> res(
        new core::regression::nearest_neighbor_regression(
            nearest_neighbor_engine,
-           conf.nearest_neighbor_num));
+           conf));
   return res;
 }
 
 shared_ptr<core::regression::regression_base> make_inverted_index_regression() {
   shared_ptr<storage::storage_base> storage(new storage::local_storage);
+  json js(new json_object);
+  js["nearest_neighbor_num"] = to_json(5);
+  js["weight"] = to_json(std::string("distance"));
+  common::jsonconfig::config param(js);
+  core::regression::inverted_index_regression::config conf
+    = config_cast_check<core::regression::inverted_index_regression::config>(
+        param);
   return shared_ptr<core::regression::regression_base> (
-      new core::regression::cosine_similarity_regression(10));
+      new core::regression::cosine_similarity_regression(conf));
 }
 
 void regression_test::my_test() {

--- a/jubatus/core/driver/regression_test.cpp
+++ b/jubatus/core/driver/regression_test.cpp
@@ -254,3 +254,4 @@ TEST_F(regression_test, inverted_index) {
 }  // namespace driver
 }  // namespace core
 }  // namespace jubatus
+

--- a/jubatus/core/regression/cosine_similarity_regression.cpp
+++ b/jubatus/core/regression/cosine_similarity_regression.cpp
@@ -45,21 +45,27 @@ float cosine_similarity_regression::estimate(
     float sum = 0.0;
     if (config_.weight && *config_.weight == "distance") {
       float sum_w = 0.0;
-       for (std::vector<std::pair<std::string, float> >:: const_iterator
-                it = ids.begin(); it != ids.end(); ++it) {
-         const std::pair<bool, uint64_t> index =
-             values_->get_model()->exact_match(it->first);
-         float t = values_->get_model()->get_float_column(0)[index.second];
-         // The range of cosine similarity score is [-1.0, 1.0].
-         float d = (1.0 - it->second) / 2.0;
-         if (d == 0.0) {
-           // In case distance equals zero, returns the vector's target value.
-           return t;
-         } else {
-           float w = 1.0 / d;
-           sum += w * t;
-           sum_w += w;
-         }
+      if (ids[0].second == 1.0) {
+        // in case same points exists, return mean value of their target values.
+        for (std::vector<std::pair<std::string, float> >:: const_iterator
+               it = ids.begin(); it != ids.end(); ++it) {
+          if (it->second != 1.0) {
+            break;
+          }
+          const std::pair<bool, uint64_t> index =
+              values_->get_model()->exact_match(it->first);
+          sum += values_->get_model()->get_float_column(0)[index.second];
+          sum_w += 1.0;
+        }
+      } else {
+        for (std::vector<std::pair<std::string, float> >:: const_iterator
+               it = ids.begin(); it != ids.end(); ++it) {
+          float w = 1.0 / (1.0 - it->second);
+          const std::pair<bool, uint64_t> index =
+              values_->get_model()->exact_match(it->first);
+          sum += w * values_->get_model()->get_float_column(0)[index.second];
+          sum_w += w;
+        }
       }
       return sum / sum_w;
     } else {
@@ -72,7 +78,7 @@ float cosine_similarity_regression::estimate(
       return sum / ids.size();
     }
   } else {
-      return 0;
+    return 0;
   }
 }
 

--- a/jubatus/core/regression/cosine_similarity_regression.cpp
+++ b/jubatus/core/regression/cosine_similarity_regression.cpp
@@ -18,6 +18,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <cfloat>
 
 #include "cosine_similarity_regression.hpp"
 #include "nearest_neighbor_regression_util.hpp"
@@ -42,25 +43,25 @@ float cosine_similarity_regression::estimate(
         fv, ids, config_.nearest_neighbor_num);
   }
   if (ids.size() > 0) {
-    float sum = 0.0;
+    float sum = 0.f;
     if (config_.weight && *config_.weight == "distance") {
-      float sum_w = 0.0;
-      if (ids[0].second == 1.0) {
+      float sum_w = 0.f;
+      if (1.f - ids[0].second <= FLT_EPSILON) {
         // in case same points exists, return mean value of their target values.
         for (std::vector<std::pair<std::string, float> >:: const_iterator
                it = ids.begin(); it != ids.end(); ++it) {
-          if (it->second != 1.0) {
+          if (1.f - it->second > FLT_EPSILON) {
             break;
           }
           const std::pair<bool, uint64_t> index =
               values_->get_model()->exact_match(it->first);
           sum += values_->get_model()->get_float_column(0)[index.second];
-          sum_w += 1.0;
+          sum_w += 1.f;
         }
       } else {
         for (std::vector<std::pair<std::string, float> >:: const_iterator
                it = ids.begin(); it != ids.end(); ++it) {
-          float w = 1.0 / (1.0 - it->second);
+          float w = 1.f / (std::abs(1.f - it->second));
           const std::pair<bool, uint64_t> index =
               values_->get_model()->exact_match(it->first);
           sum += w * values_->get_model()->get_float_column(0)[index.second];

--- a/jubatus/core/regression/cosine_similarity_regression.hpp
+++ b/jubatus/core/regression/cosine_similarity_regression.hpp
@@ -26,8 +26,7 @@ namespace regression {
 
 class cosine_similarity_regression : public inverted_index_regression {
  public:
-  cosine_similarity_regression(
-    size_t k);
+  explicit cosine_similarity_regression(const config& conf);
   float estimate(
       const common::sfv_t& fv) const;
 

--- a/jubatus/core/regression/euclidean_distance_regression.cpp
+++ b/jubatus/core/regression/euclidean_distance_regression.cpp
@@ -19,6 +19,7 @@
 #include <utility>
 #include <map>
 #include <vector>
+#include <cfloat>
 
 #include "jubatus/util/concurrent/lock.h"
 #include "nearest_neighbor_regression_util.hpp"
@@ -43,25 +44,25 @@ float euclidean_distance_regression::estimate(
         fv, ids, config_.nearest_neighbor_num);
   }
   if (ids.size() > 0) {
-    float sum = 0.0;
+    float sum = 0.f;
     if (config_.weight && *config_.weight == "distance") {
-      float sum_w = 0.0;
-      if (ids[0].second == 0.0) {
+      float sum_w = 0.f;
+      if (-1.f * ids[0].second <= FLT_EPSILON) {
         // in case same points exist, return mean value of their target values.
         for (std::vector<std::pair<std::string, float> >:: const_iterator
                it = ids.begin(); it != ids.end(); ++it) {
-          if (it->second != 0.0) {
+          if (-1.f * it->second > FLT_EPSILON) {
             break;
           }
           const std::pair<bool, uint64_t> index =
               values_->get_model()->exact_match(it->first);
           sum += values_->get_model()->get_float_column(0)[index.second];
-          sum_w += 1.0;
+          sum_w += 1.f;
         }
       } else {
         for (std::vector<std::pair<std::string, float> >:: const_iterator
                it = ids.begin(); it != ids.end(); ++it) {
-          float w = 1.0 / (-1.0 * it->second);
+          float w = 1.f / (-1.f * it->second);
           const std::pair<bool, uint64_t> index =
               values_->get_model()->exact_match(it->first);
           sum += w * values_->get_model()->get_float_column(0)[index.second];

--- a/jubatus/core/regression/euclidean_distance_regression.hpp
+++ b/jubatus/core/regression/euclidean_distance_regression.hpp
@@ -26,8 +26,7 @@ namespace regression {
 
 class euclidean_distance_regression : public inverted_index_regression {
  public:
-  euclidean_distance_regression(
-    size_t k);
+  explicit euclidean_distance_regression(const config& conf);
   float estimate(
       const common::sfv_t& fv) const;
 

--- a/jubatus/core/regression/inverted_index_regression.cpp
+++ b/jubatus/core/regression/inverted_index_regression.cpp
@@ -37,11 +37,19 @@ namespace jubatus {
 namespace core {
 namespace regression {
 
+const size_t DEFAULT_NEIGHBOR_NUM = 10;
+const std::string DEFAULT_WEIGHT = "uniform";
+
+inverted_index_regression::config::config()
+    : nearest_neighbor_num(DEFAULT_NEIGHBOR_NUM),
+      weight(DEFAULT_WEIGHT) {
+}
+
 inverted_index_regression::inverted_index_regression(
-    size_t k) :
+    const config& conf) :
   mixable_storage_(),
-  k_(k) {
-  if (!(k >= 1)) {
+  config_(conf) {
+  if (!(conf.nearest_neighbor_num >= 1)) {
     throw JUBATUS_EXCEPTION(common::invalid_parameter(
         "nearest neighbor num >= 1"));
   }

--- a/jubatus/core/regression/inverted_index_regression.cpp
+++ b/jubatus/core/regression/inverted_index_regression.cpp
@@ -53,6 +53,12 @@ inverted_index_regression::inverted_index_regression(
     throw JUBATUS_EXCEPTION(common::invalid_parameter(
         "nearest neighbor num >= 1"));
   }
+  if (conf.weight) {
+    if (!(*conf.weight == "distance") && !(*conf.weight == "uniform")) {
+      throw JUBATUS_EXCEPTION(common::invalid_parameter(
+        "weight option must be distance or uniform"));
+    }
+  }
   typedef storage::inverted_index_storage ii_storage;
   typedef storage::mixable_inverted_index_storage mii_storage;
   jubatus::util::lang::shared_ptr<ii_storage> p(new ii_storage);

--- a/jubatus/core/regression/inverted_index_regression.hpp
+++ b/jubatus/core/regression/inverted_index_regression.hpp
@@ -27,7 +27,7 @@
 #include "jubatus/util/concurrent/lock.h"
 #include "jubatus/util/concurrent/mutex.h"
 #include "jubatus/util/concurrent/rwmutex.h"
-
+#include "jubatus/util/data/optional.h"
 #include "../common/type.hpp"
 #include "../framework/packer.hpp"
 #include "../framework/mixable.hpp"
@@ -45,17 +45,18 @@ namespace regression {
 class inverted_index_regression : public regression_base {
  public:
   struct config {
-    config() : nearest_neighbor_num(10) {
-    }
+    config();
     int nearest_neighbor_num;
+    jubatus::util::data::optional<std::string> weight;
 
     template<typename Ar>
     void serialize(Ar& ar) {
-      ar & JUBA_MEMBER(nearest_neighbor_num);
+      ar & JUBA_MEMBER(nearest_neighbor_num)
+         & JUBA_MEMBER(weight);
     }
   };
 
-  explicit inverted_index_regression(size_t k);
+  explicit inverted_index_regression(const config& config);
   void train(const common::sfv_t& fv, const float value);
   virtual float estimate(const common::sfv_t& fv) const = 0;
   std::string name() const;
@@ -73,7 +74,7 @@ class inverted_index_regression : public regression_base {
       mixable_storage_;
   jubatus::util::lang::shared_ptr<framework::mixable_versioned_table> values_;
   // A map from label to number of records that belongs to the label.
-  size_t k_;
+  config config_;
   mutable jubatus::util::concurrent::rw_mutex storage_mutex_;
   jubatus::util::concurrent::mutex rand_mutex_;
   jubatus::util::math::random::mtrand rand_;

--- a/jubatus/core/regression/nearest_neighbor_regression.cpp
+++ b/jubatus/core/regression/nearest_neighbor_regression.cpp
@@ -120,25 +120,25 @@ float nearest_neighbor_regression::estimate(
   nearest_neighbor_engine_->neighbor_row(fv, ids, config_.nearest_neighbor_num);
 
   if (ids.size() > 0) {
-    float sum = 0.0;
+    float sum = 0.f;
     if (config_.weight && *config_.weight == "distance") {
-      float sum_w = 0.0;
-      if (ids[0].second == 0.0) {
+      float sum_w = 0.f;
+      if (ids[0].second == 0.f) {
         // in case same points exist, return mean value of their target values.
         for (std::vector<std::pair<std::string, float> >::const_iterator
                  it = ids.begin(); it != ids.end(); ++it) {
-          if (it->second != 0.0) {
+          if (it->second != 0.f) {
             break;
           }
           const std::pair<bool, uint64_t> index =
               values_->get_model()->exact_match(it->first);
           sum += values_->get_model()->get_float_column(0)[index.second];
-          sum_w += 1.0;
+          sum_w += 1.f;
         }
       } else {
         for (std::vector<std::pair<std::string, float> >::const_iterator
                  it = ids.begin(); it != ids.end(); ++it) {
-          float w = 1.0 / it->second;
+          float w = 1.f / it->second;
           const std::pair<bool, uint64_t> index =
               values_->get_model()->exact_match(it->first);
           sum += w * values_->get_model()->get_float_column(0)[index.second];

--- a/jubatus/core/regression/nearest_neighbor_regression.hpp
+++ b/jubatus/core/regression/nearest_neighbor_regression.hpp
@@ -58,12 +58,14 @@ class nearest_neighbor_regression : public regression_base {
     std::string method;
     common::jsonconfig::config parameter;
     int nearest_neighbor_num;
+    jubatus::util::data::optional<std::string> weight;
 
     template<typename Ar>
     void serialize(Ar& ar) {
       ar & JUBA_MEMBER(method)
         & JUBA_MEMBER(parameter)
-        & JUBA_MEMBER(nearest_neighbor_num);
+        & JUBA_MEMBER(nearest_neighbor_num)
+        & JUBA_MEMBER(weight);
       unlearner_config::serialize(ar);
     }
   };
@@ -71,7 +73,7 @@ class nearest_neighbor_regression : public regression_base {
   nearest_neighbor_regression(
       jubatus::util::lang::shared_ptr<nearest_neighbor::nearest_neighbor_base>
         nearest_neighbor_engine,
-      size_t k);
+      const config& config);
 
   void train(const common::sfv_t& fv, const float value);
   float estimate(const common::sfv_t& fv) const;
@@ -96,7 +98,7 @@ class nearest_neighbor_regression : public regression_base {
   jubatus::util::lang::shared_ptr<nearest_neighbor::nearest_neighbor_base>
       nearest_neighbor_engine_;
 
-  size_t k_;
+  config config_;
   jubatus::util::concurrent::mutex unlearner_mutex_;
   jubatus::util::lang::shared_ptr<unlearner::unlearner_base> unlearner_;
   jubatus::util::lang::shared_ptr<framework::mixable_versioned_table> values_;

--- a/jubatus/core/regression/regression_factory.cpp
+++ b/jubatus/core/regression/regression_factory.cpp
@@ -98,7 +98,7 @@ shared_ptr<regression_base> regression_factory::create_regression(
             conf.method, conf.parameter, table, ""));
     shared_ptr<regression_base> res(new regression::nearest_neighbor_regression(
                                         nearest_neighbor_engine,
-                                        conf.nearest_neighbor_num));
+                                        conf));
     if (unlearner) {
       res->set_unlearner(unlearner);
     }
@@ -112,7 +112,7 @@ shared_ptr<regression_base> regression_factory::create_regression(
     regression::inverted_index_regression::config conf
       = config_cast_check<regression::inverted_index_regression::config>(param);
     return shared_ptr<regression::cosine_similarity_regression> (
-      new regression::cosine_similarity_regression(conf.nearest_neighbor_num));
+      new regression::cosine_similarity_regression(conf));
   } else if (name == "euclidean") {
     if (param.type() == jubatus::util::text::json::json::Null) {
       throw JUBATUS_EXCEPTION(
@@ -122,7 +122,7 @@ shared_ptr<regression_base> regression_factory::create_regression(
     regression::inverted_index_regression::config conf
       = config_cast_check<regression::inverted_index_regression::config>(param);
     return shared_ptr<regression::euclidean_distance_regression> (
-      new regression::euclidean_distance_regression(conf.nearest_neighbor_num));
+            new regression::euclidean_distance_regression(conf));
   } else {
     throw JUBATUS_EXCEPTION(common::unsupported_method(name));
   }

--- a/jubatus/core/regression/regression_factory.cpp
+++ b/jubatus/core/regression/regression_factory.cpp
@@ -122,7 +122,7 @@ shared_ptr<regression_base> regression_factory::create_regression(
     regression::inverted_index_regression::config conf
       = config_cast_check<regression::inverted_index_regression::config>(param);
     return shared_ptr<regression::euclidean_distance_regression> (
-            new regression::euclidean_distance_regression(conf));
+      new regression::euclidean_distance_regression(conf));
   } else {
     throw JUBATUS_EXCEPTION(common::unsupported_method(name));
   }

--- a/jubatus/core/regression/regression_factory_test.cpp
+++ b/jubatus/core/regression/regression_factory_test.cpp
@@ -96,19 +96,12 @@ TEST(regression_factory, trivial) {
   }
 
   {
-    common::jsonconfig::config param(to_json(
-      regression::normal_herd::config()));
-    shared_ptr<regression::regression_base> r =
-      f.create_regression("NHERD", param, s);
-    EXPECT_EQ(typeid(*r), typeid(regression::normal_herd&));
-  }
-
-  {
     json js(new json_object);
     js["method"] = to_json(std::string("lsh"));
     js["parameter"] = json(new json_object);
     js["parameter"]["hash_num"] = to_json(8);
     js["nearest_neighbor_num"] = to_json(5);
+    js["weight"] = to_json(std::string("distance"));
     common::jsonconfig::config param(js);
     shared_ptr<regression::regression_base> r =
       f.create_regression("NN", param, s);


### PR DESCRIPTION
This PR implements #351.

The `weight` parameter is optional and this PR implements only `distance` weight option.
If `uniform`or other weight is set, it behaves the same way as the previous version.

I checked the behavior of the distance option using this code.
https://gist.github.com/shiodat/e0920ebc299320a6e1630175a38e0bab

The config file changes as follows:
```
{
    "method": "NN",
    "parameter": {
        "method": "euclid_lsh",
        "nearest_neighbor_num": 8,
        "weight": "distance",  #new parameter(optional)
        "parameter": {
            "hash_num": 512
        }
    }
}
```