### PR TITLE
Fix compile error in gcc-6.0 and above

### DIFF
--- a/jubatus/util/lang/enable_shared_from_this.h
+++ b/jubatus/util/lang/enable_shared_from_this.h
@@ -33,7 +33,7 @@
 #define JUBATUS_UTIL_LANG_ENABLE_SHARED_FROM_THIS_H_
 
 #include <memory>
-#ifdef __GLIBCXX__
+#if defined(__GLIBCXX__) && __cplusplus <= 199711L
 #include <tr1/memory>
 #endif
 #include "shared_ptr.h"
@@ -43,7 +43,7 @@ namespace util {
 namespace lang {
 
 namespace detail {
-#ifdef __GLIBCXX__
+#if defined(__GLIBCXX__) && __cplusplus <= 199711L
 namespace enable_shared_from_this_ns = ::std::tr1;
 #else
 namespace enable_shared_from_this_ns = ::std;

--- a/jubatus/util/lang/function.h
+++ b/jubatus/util/lang/function.h
@@ -33,7 +33,7 @@
 #define JUBATUS_UTIL_LANG_FUNCTION_H_
 
 #include <functional>
-#ifdef __GLIBCXX__
+#if defined(__GLIBCXX__) && __cplusplus <= 199711L
 #include <tr1/functional>
 #endif
 
@@ -42,7 +42,7 @@ namespace util {
 namespace lang {
 
 namespace detail {
-#ifdef __GLIBCXX__
+#if defined(__GLIBCXX__) && __cplusplus <= 199711L
 namespace function_ns = ::std::tr1;
 #else
 namespace function_ns = ::std;

--- a/jubatus/util/lang/ref.h
+++ b/jubatus/util/lang/ref.h
@@ -33,7 +33,7 @@
 #define JUBATUS_UTIL_LANG_REF_H_
 
 #include <functional>
-#ifdef __GLIBCXX__
+#if defined(__GLIBCXX__) && __cplusplus <= 199711L
 #include <tr1/functional>
 #endif
 
@@ -42,7 +42,7 @@ namespace util {
 namespace lang {
 
 namespace detail {
-#ifdef __GLIBCXX__
+#if defined(__GLIBCXX__) && __cplusplus <= 199711L
 namespace ref_ns = ::std::tr1;
 #else
 namespace ref_ns = ::std;

--- a/jubatus/util/lang/shared_ptr.h
+++ b/jubatus/util/lang/shared_ptr.h
@@ -34,7 +34,7 @@
 
 #include <exception>
 #include <memory>
-#ifdef __GLIBCXX__
+#if defined(__GLIBCXX__) && __cplusplus <= 199711L
 #include <tr1/memory>
 #endif
 
@@ -64,7 +64,7 @@ template <class T>
 class enable_shared_from_this;
 
 namespace detail {
-#ifdef __GLIBCXX__
+#if defined(__GLIBCXX__) && __cplusplus <= 199711L
 namespace shared_ptr_ns = ::std::tr1;
 #else
 namespace shared_ptr_ns = ::std;

--- a/jubatus/util/lang/weak_ptr.h
+++ b/jubatus/util/lang/weak_ptr.h
@@ -33,7 +33,7 @@
 #define JUBATUS_UTIL_LANG_WEAK_PTR_H_
 
 #include <memory>
-#ifdef __GLIBCXX__
+#if defined(__GLIBCXX__) && __cplusplus <= 199711L
 #include <tr1/memory>
 #endif
 
@@ -42,7 +42,7 @@ namespace util {
 namespace lang {
 
 namespace detail {
-#ifdef __GLIBCXX__
+#if defined(__GLIBCXX__) && __cplusplus <= 199711L
 namespace weak_ptr_ns = ::std::tr1;
 #else
 namespace weak_ptr_ns = ::std;


### PR DESCRIPTION
> https://gcc.gnu.org/gcc-6/changes.html
> The default mode for C++ is now -std=gnu++14 instead of -std=gnu++98

Fixed #368