### PR TITLE
skip gmm test if JUBATUS_USE_EIGEN is undefined

### DIFF
--- a/jubatus/core/clustering/clustering_factory_test.cpp
+++ b/jubatus/core/clustering/clustering_factory_test.cpp
@@ -182,6 +182,7 @@ TEST(clustering_factory_test, kmeans) {
   }
 }
 
+#ifdef JUBATUS_USE_EIGEN
 TEST(clustering_factory_test, gmm) {
   {
     json js(new json_object);
@@ -232,6 +233,8 @@ TEST(clustering_factory_test, gmm) {
                                                conf["compressor_parameter"]));
   }
 }
+#endif  // #ifdef JUBATUS_USE_EIGEN
+
 }
 }
 }


### PR DESCRIPTION
https://github.com/jubatus/jubatus_core/pull/362 causes unit test to fail when running

```
./waf configure --disable-eigen
./waf build --checkall
```

This PR fixes the problem by disabling GMM test when Eigen is unavailable.