### PR TITLE
Improve process of convert string to number.

### DIFF
--- a/jubatus/util/system/sysstat.cpp
+++ b/jubatus/util/system/sysstat.cpp
@@ -172,8 +172,8 @@ static uint64_t get_free_memory()
   ifstream fin("/proc/meminfo");
   string s;
 
-  uint64_t memfree = 0;
-  uint64_t memcached = 0;
+  int64_t memfree = 0;
+  int64_t memcached = 0;
   while (getline(fin, s)) {
     if (s.find("MemFree") == 0) {
       istringstream iss(s);
@@ -182,7 +182,7 @@ static uint64_t get_free_memory()
       string kb;
       iss >> type >> mem >> kb;
       if (mem != "") {
-        memfree = atoi(mem.c_str());
+        memfree = strtoll(mem.c_str(), NULL, 10);
         if (kb == "kB") {
           memfree *= 1000;
         }
@@ -195,7 +195,7 @@ static uint64_t get_free_memory()
       string kb;
       iss >> type >> cached >> kb;
       if (cached != "") {
-        memcached = atoi(cached.c_str());
+        memcached = strtoll(cached.c_str(), NULL, 10);
         if (kb == "kB") {
           memcached *= 1000;
         }


### PR DESCRIPTION
Dear,

I suggest modify function from `atoi` to `strtoull`.
Because  I think `strtoull` is safer than `atoi`.

For example, when data model of LLP64 or LP64, size of return value of `atoi` is 32bit(-2147483648 - +2147483647).
(Because type of return value of `atoi` is int).

And unit of "MemFree" and "Cashed" are "kb".So, the maximum that can be converted size are about 2TB with `atoi`.

Memory size of many 64bit system is over 2TB.So, `atoi` have maybe occurred over flow when a computer have over 2TB memory.

When `atoi` occurred over flow, action of `atoi` is undefined.
So, I think suggest use `strtoull` instead `atoi`.