### PR TITLE
add epsilon decreasing algorithm

### DIFF
--- a/jubatus/core/bandit/bandit_factory.cpp
+++ b/jubatus/core/bandit/bandit_factory.cpp
@@ -19,6 +19,7 @@
 #include <string>
 #include "../common/jsonconfig.hpp"
 #include "epsilon_greedy.hpp"
+#include "epsilon_decreasing.hpp"
 #include "ucb1.hpp"
 #include "ts.hpp"
 #include "softmax.hpp"
@@ -45,6 +46,16 @@ shared_ptr<bandit_base> bandit_factory::create(
       config_cast_check<epsilon_greedy::config>(param);
     return shared_ptr<bandit_base>(
         new epsilon_greedy(conf));
+  } else if (name == "epsilon_decreasing") {
+    if (param.type() == json::json::Null) {
+      throw JUBATUS_EXCEPTION(
+          common::config_exception() << common::exception::error_message(
+              "parameter block is not specified in config"));
+    }
+    epsilon_decreasing::config conf =
+      config_cast_check<epsilon_decreasing::config>(param);
+    return shared_ptr<bandit_base>(
+        new epsilon_decreasing(conf));
   } else if (name == "ucb1") {
     if (param.type() == json::json::Null) {
       throw JUBATUS_EXCEPTION(

--- a/jubatus/core/bandit/bandit_factory_test.cpp
+++ b/jubatus/core/bandit/bandit_factory_test.cpp
@@ -48,6 +48,27 @@ TEST(bandit_factory, epsilon_greedy_seed) {
   EXPECT_EQ("epsilon_greedy", p->name());
 }
 
+TEST(bandit_factory, epsilon_decreasing) {
+  json::json js(new json::json_object);
+  js["assume_unrewarded"] = json::to_json(true);
+  js["d"] = json::to_json(0.5);
+  common::jsonconfig::config conf(js);
+  shared_ptr<bandit_base> p =
+    bandit_factory::create("epsilon_decreasing", conf);
+  EXPECT_EQ("epsilon_decreasing", p->name());
+}
+
+TEST(bandit_factory, epsilon_decreasing_seed) {
+  json::json js(new json::json_object);
+  js["assume_unrewarded"] = json::to_json(true);
+  js["d"] = json::to_json(0.5);
+  js["seed"] = json::to_json(10);
+  common::jsonconfig::config conf(js);
+  shared_ptr<bandit_base> p =
+    bandit_factory::create("epsilon_decreasing", conf);
+  EXPECT_EQ("epsilon_decreasing", p->name());
+}
+
 TEST(bandit_factory, ucb1) {
   json::json js(new json::json_object);
   js["assume_unrewarded"] = json::to_json(true);

--- a/jubatus/core/bandit/bandit_factory_test.cpp
+++ b/jubatus/core/bandit/bandit_factory_test.cpp
@@ -51,7 +51,7 @@ TEST(bandit_factory, epsilon_greedy_seed) {
 TEST(bandit_factory, epsilon_decreasing) {
   json::json js(new json::json_object);
   js["assume_unrewarded"] = json::to_json(true);
-  js["d"] = json::to_json(0.5);
+  js["decreasing_rate"] = json::to_json(0.5);
   common::jsonconfig::config conf(js);
   shared_ptr<bandit_base> p =
     bandit_factory::create("epsilon_decreasing", conf);
@@ -61,7 +61,7 @@ TEST(bandit_factory, epsilon_decreasing) {
 TEST(bandit_factory, epsilon_decreasing_seed) {
   json::json js(new json::json_object);
   js["assume_unrewarded"] = json::to_json(true);
-  js["d"] = json::to_json(0.5);
+  js["decreasing_rate"] = json::to_json(0.5);
   js["seed"] = json::to_json(10);
   common::jsonconfig::config conf(js);
   shared_ptr<bandit_base> p =

--- a/jubatus/core/bandit/epsilon_decreasing.cpp
+++ b/jubatus/core/bandit/epsilon_decreasing.cpp
@@ -30,10 +30,10 @@ namespace core {
 namespace bandit {
 
 epsilon_decreasing::epsilon_decreasing(const config& conf)
-    : d_(conf.d), s_(conf.assume_unrewarded) {
-  if (conf.d <= 0 || 1 < conf.d) {
+    : d_(conf.decreasing_rate), s_(conf.assume_unrewarded) {
+  if (conf.decreasing_rate <= 0 || 1 <= conf.decreasing_rate) {
     throw JUBATUS_EXCEPTION(
-        common::invalid_parameter("0 < d <= 1"));
+        common::invalid_parameter("0 < d < 1"));
   }
   if (conf.seed) {
     if (*conf.seed < 0 || std::numeric_limits<uint32_t>::max() < *conf.seed) {

--- a/jubatus/core/bandit/epsilon_decreasing.cpp
+++ b/jubatus/core/bandit/epsilon_decreasing.cpp
@@ -1,0 +1,126 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2015 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+#include "epsilon_decreasing.hpp"
+
+#include <string>
+#include <vector>
+#include <limits>
+#include <algorithm>
+
+#include "../common/exception.hpp"
+#include "../framework/packer.hpp"
+#include "../common/version.hpp"
+
+namespace jubatus {
+namespace core {
+namespace bandit {
+
+epsilon_decreasing::epsilon_decreasing(const config& conf)
+    : d_(conf.d), s_(conf.assume_unrewarded) {
+  if (conf.d <= 0 || 1 < conf.d) {
+    throw JUBATUS_EXCEPTION(
+        common::invalid_parameter("0 < d <= 1"));
+  }
+  if (conf.seed) {
+    if (*conf.seed < 0 || std::numeric_limits<uint32_t>::max() < *conf.seed) {
+      throw JUBATUS_EXCEPTION(
+          common::config_exception() << common::exception::error_message(
+              "seed must be within unsigned 32 bit integer"));
+    }
+    rand_ = jubatus::util::math::random::mtrand(*conf.seed);
+  }
+}
+
+std::string epsilon_decreasing::select_arm(const std::string& player_id) {
+  const std::vector<std::string>& arms = s_.get_arm_ids();
+  if (arms.empty()) {
+    throw JUBATUS_EXCEPTION(
+        common::exception::runtime_error("arm is not registered"));
+  }
+  std::string result;
+  int total_trial = s_.get_total_trial_count(player_id) + 1;
+  double log_total_trial = std::log(total_trial);
+  double eps = 5 * arms.size() * (log_total_trial / total_trial) / (d_ * d_);
+  double dec_eps = std::min(1.0, eps);
+  if (rand_.next_double() < dec_eps) {
+    // exploration
+    result = arms[rand_.next_int(arms.size())];
+  } else {
+    // exploitation
+    result = arms[0];
+    double exp_max = s_.get_expectation(player_id, arms[0]);
+    for (size_t i = 1; i < arms.size(); ++i) {
+      double exp = s_.get_expectation(player_id, arms[i]);
+      if (exp > exp_max) {
+        result = arms[i];
+        exp_max = exp;
+      }
+    }
+  }
+  s_.notify_selected(player_id, result);
+  return result;
+}
+
+bool epsilon_decreasing::register_arm(const std::string& arm_id) {
+  return s_.register_arm(arm_id);
+}
+bool epsilon_decreasing::delete_arm(const std::string& arm_id) {
+  return s_.delete_arm(arm_id);
+}
+
+bool epsilon_decreasing::register_reward(const std::string& player_id,
+                                     const std::string& arm_id,
+                                     double reward) {
+  return s_.register_reward(player_id, arm_id, reward);
+}
+
+arm_info_map epsilon_decreasing::get_arm_info(
+  const std::string& player_id) const {
+  return s_.get_arm_info_map(player_id);
+}
+
+bool epsilon_decreasing::reset(const std::string& player_id) {
+  return s_.reset(player_id);
+}
+void epsilon_decreasing::clear() {
+  s_.clear();
+}
+
+void epsilon_decreasing::pack(framework::packer& pk) const {
+  pk.pack(s_);
+}
+void epsilon_decreasing::unpack(msgpack::object o) {
+  o.convert(&s_);
+}
+
+void epsilon_decreasing::get_diff(diff_t& diff) const {
+  s_.get_diff(diff);
+}
+bool epsilon_decreasing::put_diff(const diff_t& diff) {
+  return s_.put_diff(diff);
+}
+void epsilon_decreasing::mix(const diff_t& lhs, diff_t& rhs) const {
+  s_.mix(lhs, rhs);
+}
+
+storage::version epsilon_decreasing::get_version() const {
+  return storage::version();
+}
+
+}  // namespace bandit
+}  // namespace core
+}  // namespace jubatus

--- a/jubatus/core/bandit/epsilon_decreasing.hpp
+++ b/jubatus/core/bandit/epsilon_decreasing.hpp
@@ -1,0 +1,86 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2015 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+#ifndef JUBATUS_CORE_BANDIT_EPSILON_DECREASING_HPP_
+#define JUBATUS_CORE_BANDIT_EPSILON_DECREASING_HPP_
+
+#include <string>
+
+#include "jubatus/util/data/serialization.h"
+#include "jubatus/util/data/optional.h"
+#include "bandit_base.hpp"
+#include "summation_storage.hpp"
+#include "jubatus/util/math/random.h"
+
+namespace jubatus {
+namespace core {
+namespace bandit {
+
+class epsilon_decreasing : public bandit_base {
+ public:
+  struct config {
+    bool assume_unrewarded;
+    double d;
+    jubatus::util::data::optional<int64_t> seed;
+
+    template<class Ar>
+    void serialize(Ar& ar) {
+      ar
+        & JUBA_MEMBER(assume_unrewarded)
+        & JUBA_MEMBER(d)
+        & JUBA_MEMBER(seed);
+    }
+  };
+
+  explicit epsilon_decreasing(const config& conf);
+
+  std::string select_arm(const std::string& player_id);
+
+  bool register_arm(const std::string& arm_id);
+  bool delete_arm(const std::string& arm_id);
+
+  bool register_reward(const std::string& player_id,
+                       const std::string& arm_id,
+                       double reward);
+
+  arm_info_map get_arm_info(const std::string& player_id) const;
+
+  bool reset(const std::string& player_id);
+  void clear();
+
+  std::string name() const {
+    return "epsilon_decreasing";
+  }
+
+  void pack(framework::packer& pk) const;
+  void unpack(msgpack::object o);
+
+  void get_diff(diff_t& diff) const;
+  bool put_diff(const diff_t& diff);
+  void mix(const diff_t& lhs, diff_t& rhs) const;
+  storage::version get_version() const;
+
+ private:
+  double d_;
+  jubatus::util::math::random::mtrand rand_;
+  summation_storage s_;
+};
+
+}  // namespace bandit
+}  // namespace core
+}  // namespace jubatus
+
+#endif  // JUBATUS_CORE_BANDIT_EPSILON_DECREASING_HPP_

--- a/jubatus/core/bandit/epsilon_decreasing.hpp
+++ b/jubatus/core/bandit/epsilon_decreasing.hpp
@@ -33,14 +33,14 @@ class epsilon_decreasing : public bandit_base {
  public:
   struct config {
     bool assume_unrewarded;
-    double d;
+    double decreasing_rate;
     jubatus::util::data::optional<int64_t> seed;
 
     template<class Ar>
     void serialize(Ar& ar) {
       ar
         & JUBA_MEMBER(assume_unrewarded)
-        & JUBA_MEMBER(d)
+        & JUBA_MEMBER(decreasing_rate)
         & JUBA_MEMBER(seed);
     }
   };

--- a/jubatus/core/bandit/wscript
+++ b/jubatus/core/bandit/wscript
@@ -6,6 +6,7 @@ def build(bld):
   source = [
       'bandit_factory.cpp',
       'epsilon_greedy.cpp',
+      'epsilon_decreasing.cpp',
       'exp3.cpp',
       'select_by_weights.cpp',
       'softmax.cpp',
@@ -18,6 +19,7 @@ def build(bld):
       'bandit_base.hpp',
       'bandit_factory.hpp',
       'epsilon_greedy.hpp',
+      'epsilon_decreasing.hpp',
       'exp3.hpp',
       'select_by_weights.hpp',
       'softmax.hpp',


### PR DESCRIPTION
(ref : #354 )

Add epsilon decreasing algorithm referring to GreedyMix algorithm in [ref](https://pdfs.semanticscholar.org/2c50/eccfb2878cc7e4286791f582f96c52a26da9.pdf).
From the reference, epsilon is updated by following equation.

![formula](https://user-images.githubusercontent.com/13255255/29113127-28fef40c-7d2b-11e7-9791-3d400ecb08b2.png)

Here is the result table of slot machine experiment based on the [Jubatus example](https://github.com/jubatus/jubatus-example) 
You can see the experiment detail [here](https://gist.github.com/imaimai1125/e8352f680415311509fe1306006b81b7)

|Algorithm|Parameter|Ave. of reward|Selection Rate of optimal arm|
|---|---|---|---|
|epsilon-decreasing|0.5|46020|**0.707**|
|epsilon-decreasing|0.7|**46443**|**0.689**|
|epsilon-decreasing|1.0|**46163**|0.630|
|epilon-greedy|0.01|35392|0.155|
|epilon-greedy|0.1|44819|0.587|
|epilon-greedy|0.3|45169|0.614|
|epilon-greedy|0.9|40735|0.378|
|ucb1|-|35773|0.170|
|softmax|0.05|40908|0.440|
|exp3|0.1|**47365**|**0.801**|

(Note that the result of bandit depends on data.)
Epsilon-decreasing algorithm outperforms epsilon-greedy algorithm with any parameters.
