### PR TITLE
Support save/load of unlearner

### DIFF
--- a/jubatus/core/classifier/nearest_neighbor_classifier.hpp
+++ b/jubatus/core/classifier/nearest_neighbor_classifier.hpp
@@ -76,7 +76,7 @@ class nearest_neighbor_classifier : public classifier_base {
   storage::labels labels_;
   size_t k_;
   float alpha_;
-  jubatus::util::concurrent::mutex unlearner_mutex_;
+  mutable jubatus::util::concurrent::mutex unlearner_mutex_;
   jubatus::util::lang::shared_ptr<unlearner::unlearner_base> unlearner_;
   jubatus::util::concurrent::mutex rand_mutex_;
   jubatus::util::math::random::mtrand rand_;

--- a/jubatus/core/common/unordered_set.hpp
+++ b/jubatus/core/common/unordered_set.hpp
@@ -1,0 +1,63 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2017 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+#ifndef JUBATUS_CORE_COMMON_UNORDERED_SET_HPP_
+#define JUBATUS_CORE_COMMON_UNORDERED_SET_HPP_
+
+#include <msgpack.hpp>
+#include "jubatus/util/data/unordered_set.h"
+
+// to make util::data::unordered_set serializable
+
+namespace msgpack {
+
+template<typename V, typename H, typename P, typename A>
+inline jubatus::util::data::unordered_set<V, H, P, A> operator>>(
+    object o,
+    jubatus::util::data::unordered_set<V, H, P, A>& v) {
+  if (o.type != type::ARRAY) {
+    throw type_error();
+  }
+  object* p = o.via.array.ptr + o.via.array.size;
+  object* const pbegin = o.via.array.ptr;
+  while (p > pbegin) {
+    --p;
+    v.insert(p->as<V>());
+  }
+  return v;
+}
+
+template<typename Stream,
+         typename V,
+         typename H,
+         typename P,
+         typename A>
+inline packer<Stream>& operator<<(
+    packer<Stream>& o,
+    const jubatus::util::data::unordered_set<V, H, P, A>& v) {
+  o.pack_array(v.size());
+  typedef typename
+    jubatus::util::data::unordered_set<V, H, P, A>::const_iterator
+    iter_t;
+  for (iter_t it = v.begin(); it != v.end(); ++it) {
+    o.pack(*it);
+  }
+  return o;
+}
+
+}  // namespace msgpack
+
+#endif  // JUBATUS_CORE_COMMON_UNORDERED_SET_HPP_

--- a/jubatus/core/common/wscript
+++ b/jubatus/core/common/wscript
@@ -30,6 +30,7 @@ def build(bld):
       'thread_pool.hpp',
       'type.hpp',
       'unordered_map.hpp',
+      'unordered_set.hpp',
       'vector_util.hpp',
       'version.hpp',
       'jsonconfig/cast.hpp',

--- a/jubatus/core/recommender/inverted_index.cpp
+++ b/jubatus/core/recommender/inverted_index.cpp
@@ -135,17 +135,37 @@ string inverted_index::type() const {
 }
 
 void inverted_index::pack(framework::packer& packer) const {
-  packer.pack_array(2);
+  if (unlearner_) {
+    packer.pack_array(3);
+    unlearner_->pack(packer);
+  } else {
+    packer.pack_array(2);
+  }
+
   orig_.pack(packer);
   mixable_storage_->get_model()->pack(packer);
 }
 
 void inverted_index::unpack(msgpack::object o) {
-  if (o.type != msgpack::type::ARRAY || o.via.array.size != 2) {
+  if (o.type != msgpack::type::ARRAY) {
     throw msgpack::type_error();
   }
-  orig_.unpack(o.via.array.ptr[0]);
-  mixable_storage_->get_model()->unpack(o.via.array.ptr[1]);
+
+  size_t i = 0;
+
+  if (unlearner_) {
+    if (o.via.array.size != 3) {
+      throw msgpack::type_error();
+    }
+
+    unlearner_->unpack(o.via.array.ptr[i]);
+    ++i;
+  } else if (o.via.array.size != 2) {
+    throw msgpack::type_error();
+  }
+
+  orig_.unpack(o.via.array.ptr[i]);
+  mixable_storage_->get_model()->unpack(o.via.array.ptr[i+1]);
 }
 
 framework::mixable* inverted_index::get_mixable() const {

--- a/jubatus/core/recommender/lsh.cpp
+++ b/jubatus/core/recommender/lsh.cpp
@@ -190,17 +190,37 @@ void lsh::initialize_model() {
 }
 
 void lsh::pack(framework::packer& packer) const {
-  packer.pack_array(2);
+  if (unlearner_) {
+    packer.pack_array(3);
+    unlearner_->pack(packer);
+  } else {
+    packer.pack_array(2);
+  }
+
   orig_.pack(packer);
   mixable_storage_->get_model()->pack(packer);
 }
 
 void lsh::unpack(msgpack::object o) {
-  if (o.type != msgpack::type::ARRAY || o.via.array.size != 2) {
+  if (o.type != msgpack::type::ARRAY) {
     throw msgpack::type_error();
   }
-  orig_.unpack(o.via.array.ptr[0]);
-  mixable_storage_->get_model()->unpack(o.via.array.ptr[1]);
+
+  size_t i = 0;
+
+  if (unlearner_) {
+    if (o.via.array.size != 3) {
+      throw msgpack::type_error();
+    }
+
+    unlearner_->unpack(o.via.array.ptr[i]);
+    ++i;
+  } else if (o.via.array.size != 2) {
+    throw msgpack::type_error();
+  }
+
+  orig_.unpack(o.via.array.ptr[i]);
+  mixable_storage_->get_model()->unpack(o.via.array.ptr[i+1]);
 }
 
 }  // namespace recommender

--- a/jubatus/core/recommender/minhash.cpp
+++ b/jubatus/core/recommender/minhash.cpp
@@ -248,17 +248,37 @@ void minhash::initialize_model() {
 }
 
 void minhash::pack(framework::packer& packer) const {
-  packer.pack_array(2);
+  if (unlearner_) {
+    packer.pack_array(3);
+    unlearner_->pack(packer);
+  } else {
+    packer.pack_array(2);
+  }
+
   orig_.pack(packer);
   mixable_storage_->get_model()->pack(packer);
 }
 
 void minhash::unpack(msgpack::object o) {
-  if (o.type != msgpack::type::ARRAY || o.via.array.size != 2) {
+  if (o.type != msgpack::type::ARRAY) {
     throw msgpack::type_error();
   }
-  orig_.unpack(o.via.array.ptr[0]);
-  mixable_storage_->get_model()->unpack(o.via.array.ptr[1]);
+
+  size_t i = 0;
+
+  if (unlearner_) {
+    if (o.via.array.size != 3) {
+      throw msgpack::type_error();
+    }
+
+    unlearner_->unpack(o.via.array.ptr[i]);
+    ++i;
+  } else if (o.via.array.size != 2) {
+    throw msgpack::type_error();
+  }
+
+  orig_.unpack(o.via.array.ptr[i]);
+  mixable_storage_->get_model()->unpack(o.via.array.ptr[i+1]);
 }
 
 }  // namespace recommender

--- a/jubatus/core/regression/nearest_neighbor_regression.cpp
+++ b/jubatus/core/regression/nearest_neighbor_regression.cpp
@@ -178,17 +178,36 @@ void nearest_neighbor_regression::get_status(
 }
 
 void nearest_neighbor_regression::pack(framework::packer& pk) const {
-  pk.pack_array(2);
+  if (unlearner_) {
+    pk.pack_array(3);
+    unlearner_->pack(pk);
+  } else {
+    pk.pack_array(2);
+  }
+
   nearest_neighbor_engine_->pack(pk);
   values_->get_model()->pack(pk);
 }
 
 void nearest_neighbor_regression::unpack(msgpack::object o) {
-  if (o.type != msgpack::type::ARRAY || o.via.array.size != 2) {
+  if (o.type != msgpack::type::ARRAY) {
     throw msgpack::type_error();
   }
-  nearest_neighbor_engine_->unpack(o.via.array.ptr[0]);
-  values_->get_model()->unpack(o.via.array.ptr[1]);
+
+  size_t i = 0;
+  if (unlearner_) {
+    if (o.via.array.size != 3) {
+      throw msgpack::type_error();
+    }
+
+    unlearner_->unpack(o.via.array.ptr[i]);
+    ++i;
+  } else if (o.via.array.size != 2) {
+    throw msgpack::type_error();
+  }
+
+  nearest_neighbor_engine_->unpack(o.via.array.ptr[i]);
+  values_->get_model()->unpack(o.via.array.ptr[i+1]);
 }
 
 std::vector<framework::mixable*> nearest_neighbor_regression::get_mixables() {

--- a/jubatus/core/unlearner/lru_unlearner.cpp
+++ b/jubatus/core/unlearner/lru_unlearner.cpp
@@ -144,6 +144,15 @@ void lru_unlearner::get_status(
     jubatus::util::lang::lexical_cast<std::string>(sticky_ids_.size());
 }
 
+void lru_unlearner::pack(framework::packer& pk) const {
+  pk.pack(*this);
+}
+
+void lru_unlearner::unpack(msgpack::object o) {
+  o.convert(this);
+  lru_unlearner::rebuild_entry_map();
+}
+
 }  // namespace unlearner
 }  // namespace core
 }  // namespace jubatus

--- a/jubatus/core/unlearner/lru_unlearner.hpp
+++ b/jubatus/core/unlearner/lru_unlearner.hpp
@@ -26,6 +26,8 @@
 #include "jubatus/util/data/unordered_set.h"
 #include "jubatus/util/data/optional.h"
 #include "jubatus/util/lang/shared_ptr.h"
+#include "../common/unordered_map.hpp"
+#include "../common/unordered_set.hpp"
 #include "unlearner_base.hpp"
 
 namespace jubatus {
@@ -65,6 +67,10 @@ class lru_unlearner : public unlearner_base {
   bool remove(const std::string& id);
   bool exists_in_memory(const std::string& id) const;
   void get_status(std::map<std::string, std::string>& status) const;
+  void pack(framework::packer& pk) const;
+  void unpack(msgpack::object o);
+
+  MSGPACK_DEFINE(lru_, sticky_ids_);
 
  private:
   typedef std::list<std::string> lru;

--- a/jubatus/core/unlearner/random_unlearner.cpp
+++ b/jubatus/core/unlearner/random_unlearner.cpp
@@ -100,6 +100,14 @@ void random_unlearner::get_status(
     jubatus::util::lang::lexical_cast<std::string>(ids_.size());
 }
 
+void random_unlearner::pack(framework::packer& pk) const {
+  pk.pack(*this);
+}
+
+void random_unlearner::unpack(msgpack::object o) {
+  o.convert(this);
+}
+
 }  // namespace unlearner
 }  // namespace core
 }  // namespace jubatus

--- a/jubatus/core/unlearner/random_unlearner.hpp
+++ b/jubatus/core/unlearner/random_unlearner.hpp
@@ -24,6 +24,7 @@
 #include "jubatus/util/data/serialization.h"
 #include "jubatus/util/data/unordered_map.h"
 #include "jubatus/util/math/random.h"
+#include "../common/unordered_map.hpp"
 #include "unlearner_base.hpp"
 
 namespace jubatus {
@@ -59,6 +60,10 @@ class random_unlearner : public unlearner_base {
   bool remove(const std::string& id);
   bool exists_in_memory(const std::string& id) const;
   void get_status(std::map<std::string, std::string>& status) const;
+  void pack(framework::packer& pk) const;
+  void unpack(msgpack::object o);
+
+  MSGPACK_DEFINE(id_map_, ids_);
 
  private:
   /**

--- a/jubatus/core/unlearner/unlearner_base.hpp
+++ b/jubatus/core/unlearner/unlearner_base.hpp
@@ -20,6 +20,7 @@
 #include <string>
 #include <map>
 #include "jubatus/util/lang/function.h"
+#include "../framework/packer.hpp"
 
 namespace jubatus {
 namespace core {
@@ -73,6 +74,9 @@ class unlearner_base {
   // not been touched since then, this function returns false. If |id| has been
   // touched and not unlearned since then, it returns true.
   virtual bool exists_in_memory(const std::string& id) const = 0;
+
+  virtual void pack(framework::packer& pk) const = 0;
+  virtual void unpack(msgpack::object o) = 0;
 
  protected:
   void unlearn(const std::string& id) const {

--- a/jubatus/core/unlearner/unlearner_base_test.cpp
+++ b/jubatus/core/unlearner/unlearner_base_test.cpp
@@ -55,6 +55,12 @@ class mock_unlearner : public unlearner_base {
     // mock unlearner does not remember anything
     return false;
   }
+
+  void pack(framework::packer& pk) const {
+  }
+
+  void unpack(msgpack::object o) {
+  }
 };
 
 }  // namespace


### PR DESCRIPTION
Fixes https://github.com/jubatus/jubatus_core/issues/389

I implemented ``pack`` and ``unpack`` interface to ``unlearner``.

And, I implemented this method call to algorithms:

- [x] anomaly::light_lof
- [x] anomaly::lof
- [x] classifier::linear_classifier
- [x] classifier::nearest_neighbor_classifier
- [x] nearest_neighbor
- [x] recommender::euclid_lsh
- [x] recommender::inverted_index
- [x] recommender::inverted_index_euclid
- [x] recommender::lsh
- [x] recommender::minhash
- [x] recommender::nearest_neighbor_recommender
- [x] regression::nearest_neighbor_regression

I tested this patch using [this](https://github.com/rimms/misc/tree/master/jubatus_core-389) .

Note that nearest_neighbor does not support `unlearner`. But `driver::nearest_neighbor` has the [interface](https://github.com/jubatus/jubatus_core/blob/master/jubatus/core/driver/nearest_neighbor.hpp#L53) using `unlearner`. I think this method will not be called from anywhere.